### PR TITLE
Fix sidebar overlap in units analysis page.

### DIFF
--- a/client/app/reporting/reporting.scss
+++ b/client/app/reporting/reporting.scss
@@ -1,11 +1,10 @@
 .br-mailbox-list {
   left: auto !important;
   width: auto !important;
-  z-index: aut !important;
 }
 
 .reporting-unit-body {
-  margin-left: 220px !important;
+  margin-left: 300px !important;
 }
 
 .progress-bar-step {


### PR DESCRIPTION
NOTE: There's still an issue where the entire page scrolls horizontally a little bit unnecessarily. I'll fix that separately.

![selection_126](https://user-images.githubusercontent.com/3220897/51281481-5b0f5b80-1997-11e9-8979-78975d9b5cb7.png)
