### PR TITLE
Proper fix for units sidebar overlap.

### DIFF
--- a/client/app/reporting/reporting.scss
+++ b/client/app/reporting/reporting.scss
@@ -1,10 +1,9 @@
 .br-mailbox-list {
   left: auto !important;
-  width: auto !important;
 }
 
 .reporting-unit-body {
-  margin-left: 300px !important;
+  margin-left: 220px !important;
 }
 
 .progress-bar-step {

--- a/client/themes/bracket-plus/scss/app.scss
+++ b/client/themes/bracket-plus/scss/app.scss
@@ -1298,7 +1298,7 @@
   top: $br-header-height;
   bottom: 0;
   left: $br-sideleft-width;
-  width: 320px;
+  width: 220px;
   overflow-y: auto;
   background-color: #fff;
   z-index: 100;


### PR DESCRIPTION
I must have gotten a false positive when testing my initial fix for the sidenav overlap issue. There was some extra space on the left when testing on a different computer. It should be consistent now. I also reduced the width of that sidenav a little bit since it didn't need to be so wide.

<img width="1440" alt="screen shot 2019-01-17 at 9 19 09 pm" src="https://user-images.githubusercontent.com/3220897/51367029-9e53f200-1a9d-11e9-9d0a-44bf0934ba79.png">
