### PR TITLE
Subscription expired user lockout.

### DIFF
--- a/client/components/auth/router.decorator.js
+++ b/client/components/auth/router.decorator.js
@@ -31,7 +31,7 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
         content: `
           Please renew your subscription. You have <strong>${daysRemainingText}</strong> remaining before your service will be suspended.<br/>
           <br/>
-          To renew your subscription, please contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble in the bottom right.
+          To renew your subscription, please contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble (<i class="fa fa-comments"></i>) in the lower right corner.
         `,
         showCloseButton: false,
         enableBackdropDismiss: false,
@@ -48,7 +48,7 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
       content: `
         Your subscription renewal grace period has elapsed and service has been suspended.<br/>
         <br/>
-        To renew your subscription, please contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble in the bottom right.
+        To renew your subscription, please contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble (<i class="fa fa-comments"></i>) in the lower right corner.
       `,
       cancelButtonText: 'Refresh',
       showCloseButton: false,

--- a/client/components/auth/router.decorator.js
+++ b/client/components/auth/router.decorator.js
@@ -74,7 +74,7 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
       await refreshSubscription();
     }
 
-    if(subscription.status === 'cancelled') {
+    if(subscription && subscription.status === 'cancelled') {
       const canceledAt = moment(subscription.cancelled_at * 1000);
       const daysSinceCancellation = moment().diff(canceledAt, 'days');
 

--- a/client/components/auth/router.decorator.js
+++ b/client/components/auth/router.decorator.js
@@ -5,31 +5,84 @@ import moment from 'moment';
 export default function routerDecorator($transitions, $rootScope, $cookies, $window, Authorization, Principal, FireDepartment, Modal) {
   'ngInject';
 
+  let currentPrincipal;
   let subscription;
+  const daysToRenewSubscription = 45;
 
-  async function checkSubscriptionExpiry() {
-    // Check if the user's subscription has expired. If it is, show a dialog informing them once per day.
-    const currentPrincipal = await Principal.identity();
-    if(!currentPrincipal || !currentPrincipal.isDepartmentAdmin) {
-      return;
+  async function refreshSubscription() {
+    if(!currentPrincipal) {
+      currentPrincipal = await Principal.identity();
     }
 
-    // Only get the subscription data once to avoid unnecessary requests.
-    if(!subscription) {
+    if(currentPrincipal && currentPrincipal.isDepartmentAdmin) {
       subscription = await FireDepartment.getSubscription({ id: currentPrincipal.fire_department__id }).$promise;
     }
+  }
 
-    const shownAt = moment(parseInt($cookies.get('subscription_expiry_shown_at')) || 0);
-    if(subscription.status === 'cancelled' && moment().diff(shownAt, 'days') >= 1) {
-      Modal.confirm({
+  function showSubscriptionExpiredWarning(daysSinceCancellation) {
+    // Only show the warning once per day.
+    const shownAt = moment(parseInt($cookies.get('subscription_expiry_warning_shown_at')) || 0);
+    const daysSinceShown = moment().diff(shownAt, 'days');
+    if(daysSinceShown >= 1) {
+      const daysRemaining = daysToRenewSubscription - daysSinceCancellation;
+      const daysRemainingText = (daysRemaining === 1) ? `${daysRemaining} day` : `${daysRemaining} days`;
+      Modal.alert({
         title: 'Subscription Canceled',
-        content: 'Please renew your subscription soon to avoid any interruption of your service.',
+        content: `
+          Please renew your subscription. You have <strong>${daysRemainingText}</strong> remaining before your service will be suspended.<br/>
+          <br/>
+          To renew your subscription, please contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble in the bottom right.
+        `,
+        showCloseButton: false,
+        enableBackdropDismiss: false,
         cancelButtonText: 'Ignore',
-        confirmButtonText: 'Manage Subscription',
-        onConfirm: () => $window.open('/subscriptionPortal', '_blank'),
       }).present();
 
-      $cookies.put('subscription_expiry_shown_at', moment().valueOf());
+      $cookies.put('subscription_expiry_warning_shown_at', moment().valueOf());
+    }
+  }
+
+  function showSubscriptionExpired() {
+    const modal = Modal.custom({
+      title: 'Subscription Canceled',
+      content: `
+        Your subscription renewal grace period has elapsed and service has been suspended.<br/>
+        <br/>
+        To renew your subscription, please contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble in the bottom right.
+      `,
+      cancelButtonText: 'Refresh',
+      showCloseButton: false,
+      enableBackdropDismiss: false,
+      buttons: [{
+        text: 'Refresh',
+        style: Modal.buttonStyle.primary,
+        dismisses: false,
+        onClick: async () => {
+          await refreshSubscription();
+          if(subscription.status !== 'cancelled') {
+            modal.dismiss();
+          }
+        },
+      }],
+    });
+    modal.present();
+  }
+
+  async function checkSubscriptionExpiry() {
+    // Only get the subscription data once to avoid unnecessary requests.
+    if(!subscription) {
+      await refreshSubscription();
+    }
+
+    if(subscription.status === 'cancelled') {
+      const canceledAt = moment(subscription.cancelled_at * 1000);
+      const daysSinceCancellation = moment().diff(canceledAt, 'days');
+
+      if(daysSinceCancellation < daysToRenewSubscription) {
+        showSubscriptionExpiredWarning(daysSinceCancellation);
+      } else {
+        showSubscriptionExpired();
+      }
     }
   }
 

--- a/client/components/modal/modal.service.js
+++ b/client/components/modal/modal.service.js
@@ -9,14 +9,15 @@ export function Modal($rootScope, $uibModal) {
    * @param  {String} modalClass - (optional) class(es) to be applied to the modal
    * @return {Object}            - the instance $uibModal.open() returns
    */
-  function openModal(scope = {}, modalClass = 'modal-default') {
+  function openModal({ scope = {}, modalClass = 'modal-default', enableBackdropDismiss = true }) {
     var modalScope = $rootScope.$new();
     angular.extend(modalScope, scope);
 
     return $uibModal.open({
       template: require('./modal.html'),
       windowClass: modalClass,
-      scope: modalScope
+      scope: modalScope,
+      backdrop: enableBackdropDismiss || 'static',
     });
   }
 
@@ -34,29 +35,34 @@ export function Modal($rootScope, $uibModal) {
       content = '',
       buttons = [],
       onDismiss = angular.noop,
+      showCloseButton = true,
+      enableBackdropDismiss = true,
     }) {
       let modal;
       return {
         present: () => {
           modal = openModal({
-            modal: {
-              dismissable: true,
-              title,
-              html: `<p>${content}</p>`,
-              buttons: buttons.map(button => ({
-                classes: button.style || service.buttonStyle.default,
-                text: button.text,
-                click: (e) => {
-                  if (button.onClick) {
-                    button.onClick(e);
-                  }
-                  if (_.isUndefined(button.dismisses) || button.dismisses) {
-                    modal.dismiss();
-                  }
-                },
-              })),
+            scope: {
+              modal: {
+                title,
+                html: `<p>${content}</p>`,
+                dismissable: showCloseButton,
+                buttons: buttons.map(button => ({
+                  classes: button.style || service.buttonStyle.default,
+                  text: button.text,
+                  click: (e) => {
+                    if (button.onClick) {
+                      button.onClick(e);
+                    }
+                    if (_.isUndefined(button.dismisses) || button.dismisses) {
+                      modal.dismiss();
+                    }
+                  },
+                })),
+              },
             },
-          }, 'modal-default');
+            enableBackdropDismiss,
+          });
 
           // Call onDismiss() when the modal closes for any reason.
           modal.result
@@ -77,17 +83,21 @@ export function Modal($rootScope, $uibModal) {
     alert({
       title,
       content = '',
-      closeButtonText = 'Ok',
+      cancelButtonText = 'Ok',
       onDismiss = angular.noop,
+      showCloseButton = true,
+      enableBackdropDismiss = true,
     }) {
       return service.custom({
         title,
         content,
         buttons: [{
-          text: closeButtonText,
+          text: cancelButtonText,
           style: service.buttonStyle.primary,
         }],
         onDismiss,
+        showCloseButton,
+        enableBackdropDismiss,
       });
     },
 
@@ -98,20 +108,27 @@ export function Modal($rootScope, $uibModal) {
       cancelButtonStyle = service.buttonStyle.default,
       confirmButtonText = 'Confirm',
       confirmButtonStyle = service.buttonStyle.primary,
-      onDismiss = angular.noop,
+      onCancel = angular.noop,
       onConfirm = angular.noop,
+      onDismiss = angular.noop,
+      showCloseButton = true,
+      enableBackdropDismiss = true,
     }) {
       return service.custom({
         title,
         content,
         buttons: [{
           text: cancelButtonText,
+          style: cancelButtonStyle,
+          onClick: onCancel,
         }, {
           text: confirmButtonText,
           style: confirmButtonStyle,
           onClick: onConfirm,
         }],
         onDismiss,
+        showCloseButton,
+        enableBackdropDismiss,
       });
     },
   };

--- a/server/api/fire-department/index.js
+++ b/server/api/fire-department/index.js
@@ -90,7 +90,7 @@ router.get(
   '/:id/subscription',
   auth.isApiAuthenticated,
   auth.hasRole('user'),
-  controller.hasAdminPermission,
+  auth.hasFireDepartment,
   controller.getSubscription,
 );
 


### PR DESCRIPTION
The user should now get locked out after exceeding the 45 day grace period from when their subscription was canceled. The dialog that shows has a refresh button included so that they don't hit a dead end within the app and can refresh their subscription status without reloading the entire app.

I also updated the warning dialog that shows during the grace period. It should now show a countdown of the days remaining before your service is suspended. It also includes contact info for renewing your subscription.

I'm not sure of any way of easily testing the lockout dialog aside from canceling the subscription and then editing this line in `router.decorator.js` to make it 45 or above...
```javascript
const daysSinceCancellation = moment().diff(canceledAt, 'days');
```

### Subscription Expired
![selection_129](https://user-images.githubusercontent.com/3220897/51421611-6d36f880-1b55-11e9-8abc-b08605aea26e.png)

### Subscription Expired Warning (updated)
![selection_130](https://user-images.githubusercontent.com/3220897/51421615-71fbac80-1b55-11e9-9f93-b531f867d392.png)
