### PR TITLE
Fix floating navbar labels when it's minimized.

### DIFF
--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -1241,12 +1241,7 @@ span+.logged-name {
     }
 
     .br-sideleft .sidebar-label {
-      visibility: visible;
-
-      &::before {
-        content: '...';
-        margin-right: 400px;
-      }
+      visibility: hidden;
     }
   }
 
@@ -1271,8 +1266,8 @@ span+.logged-name {
       left: 55px;
     }
 
-    .br-sideleft .sidebar-label::before {
-      display: none;
+    .br-sideleft .sidebar-label {
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
The labels should be hidden now when the navbar is minimized and reappear if you hover over it or expand it.