### PR TITLE
Fit "My Departments" page on all screen widths.

### DIFF
--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -200,12 +200,13 @@ table td {
 }
 
 // Table Imposter Styles
-.table {
+@mixin table($max-width) {
   display: table;
   margin: 0;
   width: 100%;
+  border: solid 1px $border-color;
 
-  @media screen and (max-width: 580px) {
+  @media screen and (max-width: $max-width) {
     display: block;
   }
 
@@ -224,18 +225,13 @@ table td {
       text-transform: uppercase;
     }
 
-    @media screen and (max-width: 580px) {
+    @media screen and (max-width: $max-width) {
       padding: 14px 0 7px;
       display: block;
       border-bottom: 1px solid $color-geyser;
 
       &.header {
-        padding: 0;
-        height: 6px;
-
-        .cell {
-          display: none;
-        }
+        display: none;
       }
 
       .cell {
@@ -262,14 +258,24 @@ table td {
       display: table-cell;
       border-bottom: 1px solid $color-geyser;
 
-      @media screen and (max-width: 580px) {
+      @media screen and (max-width: $max-width) {
         padding: 2px 16px;
         display: block;
         margin-bottom: 10px;
         border-bottom: none;
       }
     }
+
+    &:last-child {
+      .cell {
+        border-bottom: none;
+      }
+    }
   }
+}
+
+.table {
+  @include table(580px);
 }
 
 // Lists
@@ -1317,6 +1323,26 @@ span+.logged-name {
   }
 }
 
+@mixin dropdown-menu-animation($origin) {
+  transform-origin: $origin;
+
+  @keyframes dropdownMenuShow {
+    0% {
+      opacity: 0;
+      transform: scale(0);
+    }
+
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  &.show {
+    animation: dropdownMenuShow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+}
+
 /////////////////////////////////
 // IMPORT COMPONENTS //
 ////////////////////////////////
@@ -1341,6 +1367,7 @@ span+.logged-name {
 @import '../app/incident/incident';
 @import '../app/report/report';
 @import '../app/reporting/reporting';
+@import '../app/department-admin/department-admin';
 @import '../components/incident/incident';
 @import '../components/oauth-buttons/oauth-buttons';
 @import '../components/percent-change/percent-change';

--- a/client/app/department-admin/department-admin-home/department-admin-home.html
+++ b/client/app/department-admin/department-admin-home/department-admin-home.html
@@ -1,123 +1,123 @@
-<div class="br-mainpanel user-home medium-bg">
-  <div class="br-pagetitle">
-    <header class="naked"></header>
-    <section class="container site-content">
-      <section id="department-users" class="fluid-container py-5">
-        <div class="container">
-          <h3 class="mb-2" >Department Users</h3>
-          <div class="row">
-            <div class="col-12 py-4">
-              <div class="table mb-5">
-                <div class="table-row header">
-                  <div class="cell">
-                    Username
-                  </div>
-                  <div class="cell">
-                    Name
-                  </div>
-                  <div class="cell">
-                    Email
-                  </div>
-                  <div class="cell">
-                    Admin
-                  </div>
-                  <div class="cell">
-                    Ingest
-                  </div>
-                  <div class="cell">
-                    Dashboard Admin
-                  </div>
-                  <div class="cell">
-                    Dashboard Readonly
-                  </div>
-                  <div class="cell">
-                    Status
-                  </div>
-                  <div class="cell">
-                    Action
-                  </div>
-                </div>
-  
-                <div class="table-row" ng-repeat="user in vm.users | orderBy:'first_name'">
-                  <div class="cell" data-title="Username">
-                    {{ user.username }}
-                  </div>
-                  <div class="cell" data-title="Name">
-                    {{ user.first_name }} {{ user.last_name }}
-                  </div>
-                  <div class="cell" data-title="Email">
-                    {{ user.email }}
-                  </div>
-                  <div class="cell" data-title="Admin">
-                    <span ng-if="user.isDepartmentAdmin"><span class="fa fa-check text-success"></span></span>
-                  </div>
-                  <div class="cell" data-title="Ingest">
-                    <span ng-if="user.isIngest"><span class="fa fa-check text-success"></span></span>
-                  </div>
-                  <div class="cell" data-title="Kibana Admin">
-                    <span ng-if="user.isKibanaAdmin"><span class="fa fa-check text-success"></span></span>
-                  </div>
-                  <div class="cell" data-title="Kibana Admin">
-                    <span ng-if="user.isKibanaReadOnlyStrict"><span class="fa fa-check text-success"></span></span>
-                  </div>
-                  <div class="cell" data-title="Status">
-                    <span class="text-success" ng-if="user.FireDepartment">Approved</span>
-                    <span class="text-warning" ng-if="!user.FireDepartment">Pending</span>
-                  </div>
-                  <div class="cell" data-title="Action">
-                    <button class="btn btn-link" ng-click="vm.approveAccess(user)" ng-show="!user.FireDepartment" uib-popover="Approve Dashboard Access" popover-trigger="'mouseenter'"><i class="fa fa-2x fa-check-circle text-success"></i>Dashboard Admin</button><br>
-                    <button class="btn btn-link" ng-click="vm.approveAccess(user, true)" ng-show="!user.FireDepartment" uib-popover="Approve Readonly Dashboard Access" popover-trigger="'mouseenter'"><i class="fa fa-2x fa-check-circle text-success"></i>Dashboard Readonly</button><br>
-                    <button class="btn btn-link" ng-click="vm.revokeAccess(user)" uib-popover="Revoke Access" ng-show="!(user.isDepartmentAdmin || user.isIngest)" popover-trigger="'mouseenter'"><i class="fa fa-2x fa-times-circle text-danger"></i>Revoke</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+<div class="br-mainpanel department-admin-home medium-bg">
+  <section id="department-users" class="department-users">
+    <h3 class="mb-2">Department Users</h3>
+    <div class="department-users-table mb-5">
+      <div class="table-row header">
+        <div class="cell">
+          Name
         </div>
-      </section>
-      <section id="data-quality-analysis" class="fluid-container py-5 data-quality-analysis">
-        <div class="container">
-          <h3 class="mb-2" >Data Quality Analysis <span ng-class="{'badge-danger': vm.dataQuality.grade == 'POOR', 'badge-success': vm.dataQuality.grade == 'GOOD', 'badge-warning': vm.dataQuality.grade == 'NEEDS ATTENTION' || vm.dataQuality.grade == 'UNKNOWN' }" class="badge">{{vm.dataQuality.grade}}</span></h3>
-          <div class="row">
-            <div class="col-md-8">
-              <p>The quality and accuracy of your organization's data is critical in getting the most value from the StatEngine platform.  Use this table to keep an eye on things so that your data stays in tip top shape.</p>
-            </div>
-            <div class="col-12 py-4">
-              <div class="table mb-5">
-                <div class="table-row header">
-                  <div class="cell">
-                    Rule Check
-                  </div>
-                  <div class="cell">
-                    Violations
-                  </div>
-                  <div class="cell">
-                    Percentage
-                  </div>
-                  <div class="cell">
-                    Required Action
-                  </div>
-                </div>
+        <div class="cell">
+          Email
+        </div>
+        <div class="cell">
+          Permissions
+        </div>
+        <div class="cell">
+          Status
+        </div>
+        <div class="cell">
+          Action
+        </div>
+      </div>
 
-                <div class="table-row" ng-repeat="result in vm.dataQuality.results">
-                  <div class="cell" data-title="Rule Check">
-                    {{ result.rule }}
-                  </div>
-                  <div class="cell" data-title="Violations">
-                    {{ result.violations|number:0 }}
-                  </div>
-                  <div class="cell" data-title="Percentage">
-                    {{ result.percentViolation|number }}%
-                  </div>
-                  <div class="cell" data-title="Required Action">
-                    {{ result.requiredAction }}
-                  </div>
+      <div class="table-row" ng-repeat="user in vm.users | orderBy:'first_name'">
+        <div class="cell name" data-title="Name" ng-attr-title="{{ user.name }}">
+          {{ user.first_name }} {{ user.last_name }}
+        </div>
+        <div class="cell email" data-title="Email" ng-attr-title="{{ user.email }}">
+          {{ user.email }}
+        </div>
+        <div class="cell permissions" data-title="Permissions">
+          <div ng-if="user.isDepartmentAdmin">
+            <i class="fa fa-check text-success"></i> Admin
+          </div>
+          <div ng-if="user.isIngest">
+            <i class="fa fa-check text-success"></i> Ingest
+          </div>
+          <div ng-if="user.isKibanaAdmin">
+            <i class="fa fa-check text-success"></i> Dashboard Admin
+          </div>
+          <div ng-if="!user.isKibanaAdmin && user.isKibanaReadOnlyStrict">
+            <i class="fa fa-check text-success"></i> Dashboard Readonly
+          </div>
+          <div ng-if="!user.isDepartmentAdmin && !user.isIngest && !user.isKibanaAdmin && !user.isKibanaReadOnlyStrict">
+            None
+          </div>
+        </div>
+        <div class="cell status" data-title="Status">
+          <span class="badge badge-success" ng-if="user.FireDepartment">Approved</span>
+          <span class="badge badge-warning" ng-if="!user.FireDepartment">Pending</span>
+        </div>
+        <div
+          class="cell action"
+          ng-class="{'current-user': user._id === vm.principal._id}"
+          data-title="Action"
+        >
+          <div class="dropdown d-inline-block">
+            <div class="dropdown-button" data-toggle="dropdown">
+              <i class="fa fa-angle-down"></i>
+            </div>
+            <div class="dropdown-menu">
+              <nav class="nav nav-style-2 flex-column">
+                <div class="nav-link" ng-show="!user.FireDepartment" ng-click="vm.approveAccess(user)">
+                  <i class="fa fa-2x fa-check-circle"></i>
+                  <span>Approve Dashboard Admin</span>
                 </div>
-              </div>
+                <div class="nav-link"  ng-show="!user.FireDepartment" ng-click="vm.approveAccess(user, true)">
+                  <i class="fa fa-2x fa-check-circle"></i>
+                  <span>Approve Dashboard Readonly</span>
+                </div>
+                <div class="nav-link" ng-show="!user.isDepartmentAdmin && !user.isIngest" ng-click="vm.revokeAccess(user)">
+                  <i class="fa fa-2x fa-times-circle"></i>
+                  <span>Revoke Access</span>
+                </div>
+              </nav>
+            </div><!-- dropdown-menu -->
+          </div><!-- dropdown -->
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="data-quality-analysis" class="data-quality-analysis">
+    <h3 class="mb-2" >Data Quality Analysis <span ng-class="{'badge-danger': vm.dataQuality.grade == 'POOR', 'badge-success': vm.dataQuality.grade == 'GOOD', 'badge-warning': vm.dataQuality.grade == 'NEEDS ATTENTION' || vm.dataQuality.grade == 'UNKNOWN' }" class="badge">{{vm.dataQuality.grade}}</span></h3>
+    <div class="row">
+      <div class="col-xl-8">
+        <p>The quality and accuracy of your organization's data is critical in getting the most value from the StatEngine platform.  Use this table to keep an eye on things so that your data stays in tip top shape.</p>
+      </div>
+      <div class="col-12 py-4">
+        <div class="data-quality-analysis-table mb-5">
+          <div class="table-row header">
+            <div class="cell">
+              Rule Check
+            </div>
+            <div class="cell">
+              Violations
+            </div>
+            <div class="cell">
+              Percentage
+            </div>
+            <div class="cell">
+              Required Action
+            </div>
+          </div>
+
+          <div class="table-row" ng-repeat="result in vm.dataQuality.results">
+            <div class="cell" data-title="Rule Check">
+              {{ result.rule }}
+            </div>
+            <div class="cell" data-title="Violations">
+              {{ result.violations|number:0 }}
+            </div>
+            <div class="cell" data-title="Percentage">
+              {{ result.percentViolation|number }}%
+            </div>
+            <div class="cell" data-title="Required Action">
+              {{ result.requiredAction }}
             </div>
           </div>
         </div>
-      </section>
-    </section>
-  </div>
+      </div>
+    </div>
+  </section>
 </div>

--- a/client/app/department-admin/department-admin-home/department-admin-home.scss
+++ b/client/app/department-admin/department-admin-home/department-admin-home.scss
@@ -1,10 +1,4 @@
 .department-admin-home {
-  .data-quality-analysis {
-    h3 .badge {
-      margin-left: 1rem;
-    }
-  }
-
   .badge-danger {
     background-color: $color-brand-danger;
   }
@@ -19,5 +13,145 @@
 
   .badge-warning {
     background-color: #ffc107;
+  }
+
+  .department-users {
+    @extend .container-fluid;
+
+    padding-top: 2.5rem;
+    max-width: 1230px;
+
+    @media screen and (max-width: 1200px) {
+      max-width: 580px;
+    }
+
+    @include media-breakpoint-down(sm) {
+      padding-top: 1.5rem;
+    }
+
+    .department-users-table {
+      @include table(1200px);
+      @extend .my-4;
+
+      .cell {
+        vertical-align: middle;
+
+        &.name {
+          max-width: 215px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        &.email {
+          max-width: 300px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        &.admin,
+        &.ingest,
+        &.dashboard-admin,
+        &.dashboard-readonly {
+          text-align: center;
+
+          @media screen and (max-width: 1200px) {
+            text-align: left;
+          }
+        }
+
+        &.status {
+          font-size: 14px;
+          text-transform: uppercase;
+        }
+
+        &.action {
+          .dropdown {
+            display: inline-block;
+            margin-left: 8px;
+
+            @media screen and (max-width: 1200px) {
+              margin-left: 0;
+            }
+
+            .dropdown-button {
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              background: white;
+              color: $gray-800;
+              border: solid 1px $input-border-color;
+              width: 30px;
+              height: 30px;
+              cursor: pointer;
+              transition: filter 0.25s;
+
+              &:hover {
+                filter: brightness(0.95);
+              }
+            }
+
+            .dropdown-menu {
+              @include dropdown-menu-animation(top right);
+              top: auto !important;
+              bottom: auto !important;
+              left: auto !important;
+              right: 0 !important;
+              transform: unset !important;
+              padding: 0 !important;
+
+              @media screen and (max-width: 1200px) {
+                @include dropdown-menu-animation(top left);
+                left: 0 !important;
+                right: auto !important;
+              }
+
+              .nav {
+                align-items: start;
+
+                .nav-link {
+                  width: 100%;
+                  padding: 0.75rem 1rem;
+                  white-space: nowrap;
+                  display: flex;
+                  align-items: center;
+                  cursor: pointer;
+                }
+              }
+            }
+          }
+
+          &.current-user {
+            @media screen and (max-width: 1200px) {
+              display: none;
+            }
+
+            .dropdown {
+              display: none !important;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .data-quality-analysis {
+    @extend .container-fluid;
+    @extend .py-4;
+
+    max-width: 1230px;
+
+    @media screen and (max-width: 1200px) {
+      max-width: 580px;
+    }
+
+    h3 .badge {
+      margin-left: 1rem;
+    }
+
+    .data-quality-analysis-table {
+      @include table(1200px);
+    }
   }
 }

--- a/client/app/department-admin/department-admin.scss
+++ b/client/app/department-admin/department-admin.scss
@@ -1,0 +1,1 @@
+@import 'department-admin-home/department-admin-home';


### PR DESCRIPTION
I removed the **Username** column, grouped actions into a dropdown, and grouped all of the permissions into one column since those were taking up a lot of width. As well as saving space, I think it's actually easier to parse the permissions visually with them grouped. I also tweaked the styling on the status values, since "Pending" was difficult to read as just yellow text.

It should scale to all screen sizes now without any overflow. Emails and names that are too long will get truncated with an ellipsis eventually. It should rarely be an issue except on mid-size widths. However, you can hover over them to see the full value.

It didn't look like there were any actions a user could take on themselves, so I hid the actions dropdown in that case.

### Large
![selection_134](https://user-images.githubusercontent.com/3220897/51708359-9c77ba80-1fd8-11e9-866e-7032252580ab.png)

### Small
![selection_136](https://user-images.githubusercontent.com/3220897/51708372-a4375f00-1fd8-11e9-9355-ff4076d27ec0.png)
