### PR TITLE
Server-side paging and sorting in Incidents page.

### DIFF
--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -5,34 +5,46 @@
 let _;
 
 export default class IncidentSearchController {
+  page = 1;
+  pageSize = 100;
+  sort;
+  search;
+  searchInputValue;
+  isLoading = true;
+  uiGridApi;
+
   /*@ngInject*/
-  constructor(AmplitudeService, AnalyticEventNames, Incident, currentPrincipal, recentIncidents) {
+  constructor($scope, AmplitudeService, AnalyticEventNames, Incident) {
     this.IncidentService = Incident;
     this.AmplitudeService = AmplitudeService;
     this.AnalyticEventNames = AnalyticEventNames;
 
-    this.searchResultsTableOptions = {
+    this.uiGridOptions = {
       data: [],
-      paginationPageSizes: [100],
-      paginationPageSize: 100,
+      paginationPageSizes: [10, 25, 50, 100],
+      paginationPageSize: this.pageSize,
+      paginationCurrentPage: this.page,
+      totalItems: 0,
       columnDefs: [{
         field: 'description.incident_number',
         displayName: 'Incident Number',
-        cellTemplate: '<div class="ui-grid-cell-contents"><a href="#" ui-sref="site.incident.analysis({ id: grid.getCellValue(row, col) })">{{ grid.getCellValue(row, col )}}</a></div>',
+        cellTemplate: '<div class="ui-grid-cell-contents"><a href="#" ui-sref="site.incident.analysis({ id: grid.getCellValue(row, col) })">{{ grid.getCellValue(row, col ) }}</a></div>',
       }, {
         field: 'address.address_line1',
         displayName: 'Address'
       }, {
         field: 'description.event_closed',
-        displayName: 'Event Closed'
+        displayName: 'Event Closed',
       }, {
         field: 'durations.total_event.seconds',
         displayName: 'Event Duration',
         cellFilter: 'humanizeDuration',
       }, {
-        field: 'description.units.length',
+        field: 'description.units',
         displayName: '# Units',
         width: 100,
+        cellTemplate: '<div class="ui-grid-cell-contents">{{ grid.getCellValue(row, col ).length }}</div>',
+        enableSorting: false,
       }, {
         field: 'description.category',
         displayName: 'Category',
@@ -40,10 +52,16 @@ export default class IncidentSearchController {
       }, {
         field: 'description.type',
         displayName: 'Type',
-      }]
+      }],
+      useExternalPagination: true,
+      useExternalSorting: true,
+      enableHorizontalScrollbar: false,
+      onRegisterApi: (uiGridApi) => {
+        this.uiGridApi = uiGridApi;
+        uiGridApi.pagination.on.paginationChanged($scope, (newPage, pageSize) => { this.paginationChanged(newPage, pageSize) });
+        uiGridApi.core.on.sortChanged($scope, (uiGrid, sortColumns) => { this.sortChanged(uiGrid, sortColumns); });
+      },
     };
-
-    this.recentIncidents = recentIncidents;
   }
 
   async loadModules() {
@@ -52,25 +70,53 @@ export default class IncidentSearchController {
 
   async $onInit() {
     await this.loadModules();
-
-    this.formatSearchResults(this.recentIncidents);
+    this.refreshIncidentsList();
   }
 
-  formatSearchResults(results) {
-    const searchResults = [];
-
-    _.forEach(results, r => searchResults.push(r._source));
-
-    this.searchResultsTableOptions.data = searchResults;
+  paginationChanged(newPage, pageSize) {
+    this.page = newPage;
+    this.pageSize = pageSize;
+    this.refreshIncidentsList();
   }
 
-  search() {
+  sortChanged(uiGrid, sortColumns) {
+    if(sortColumns.length > 0) {
+      this.sort = sortColumns.map(column => {
+        return `${column.field},${column.sort.direction}`;
+      }).join('+');
+    } else {
+      this.sort = undefined;
+    }
+    this.refreshIncidentsList();
+  }
+
+  async refreshIncidentsList() {
+    this.uiGridOptions.data = [];
+    this.isLoading = true;
+
+    const data = await this.IncidentService.get({
+      count: this.pageSize,
+      from: (this.page - 1) * this.pageSize,
+      sort: this.sort,
+      search: this.search,
+    }).$promise;
+    this.uiGridOptions.data = data.items.map(item => item._source);
+    this.uiGridOptions.totalItems = data.totalItems;
+
+    this.isLoading = false;
+  }
+
+  async searchButtonClick() {
     this.AmplitudeService.track(this.AnalyticEventNames.APP_ACTION, {
       app: 'Incident Analysis',
       action: 'search',
     });
 
-    this.IncidentService.search({ q: this.query }).$promise
-      .then(results => this.formatSearchResults(results));
+    let search = this.searchInputValue.trim();
+    if(search === '') {
+      search = undefined;
+    }
+    this.search = search;
+    this.refreshIncidentsList();
   }
 }

--- a/client/app/incident/incident-search/incident-search.html
+++ b/client/app/incident/incident-search/incident-search.html
@@ -1,10 +1,9 @@
 <!-- TODO:
-    - Breadcrumbs needs to be hooked up
     - Table should be switched to newer style/format (Bingles)
     - Table and supporting elements need better responsive styling (Bingles)
 -->
 
-<div class="br-mainpanel medium-bg">
+<div class="incident-search br-mainpanel medium-bg">
   <div class="br-pageheader">
     <nav class="breadcrumb pd-0 mg-0 tx-12">
       <a class="breadcrumb-item" href="index.html">Home</a>
@@ -15,16 +14,28 @@
   <div class="br-pagetitle d-flex justify-content-between flex-wrap">
     <h2 class="m-0">Incidents</h2>
     <div class="input-group wd-300">
-      <input ng-model="vm.query" type="text" class="form-control" placeholder="Search Incidents">
+      <input ng-model="vm.searchInputValue" type="text" class="form-control" placeholder="Search Incidents">
       <span class="input-group-btn">
-        <button class="btn bd-0 btn-secondary py-2 px-3 rounded-0" type="button" ng-click="vm.search()"><i class="fa fa-search"></i></button>
+        <button class="btn bd-0 btn-secondary py-2 px-3 rounded-0" type="button" ng-click="vm.searchButtonClick()"><i class="fa fa-search"></i></button>
       </span>
     </div>
   </div><!-- br-pagetitle -->
   <div class="br-pagebody">
     <section class="br-section-wrapper shadow-none pd-0">
-      <div ui-grid="vm.searchResultsTableOptions" class="search-grid" ui-grid-pagination ui-grid-resize-column>
-        <div class="watermark" ng-show="!vm.searchResultsTableOptions.data.length"><h2 class="heavyheader text-muted">No data available</h2></div>
+      <div class="incidents-desktop search-grid" ui-grid="vm.uiGridOptions" ui-grid-pagination ui-grid-resize-column>
+        <h2
+          class="watermark heavyheader text-muted"
+          ng-show="!vm.isLoading && !vm.uiGridOptions.data.length"
+        >
+          No data available
+        </h2>
+        <h2
+          class="watermark heavyheader text-muted"
+          ng-show="vm.isLoading"
+        >
+          Loading...
+        </h2>
       </div>
     </section>
+  </div>
 </div>

--- a/client/app/incident/incident.routes.js
+++ b/client/app/incident/incident.routes.js
@@ -33,12 +33,6 @@ export default function routes($stateProvider) {
               $ocLazyLoad.inject('ui.grid.resizeColumns');
             });
         },
-        currentPrincipal(Principal) {
-          return Principal.identity();
-        },
-        recentIncidents(Incident) {
-          return Incident.query().$promise;
-        },
       },
     })
     .state('site.incident.analysis', {

--- a/client/components/api/incident.service.js
+++ b/client/components/api/incident.service.js
@@ -6,10 +6,6 @@ export default function IncidentResource($resource) {
   return $resource('/api/incidents/:id', {
     id: '@id',
   }, {
-    search: {
-      method: 'GET',
-      isArray: true,
-    },
     active: {
       method: 'GET',
       isArray: true,

--- a/server/api/incident/index.js
+++ b/server/api/incident/index.js
@@ -47,7 +47,7 @@ router.get(
   auth.isApiAuthenticated,
   auth.hasRole('user'),
   auth.hasFireDepartment,
-  controller.getRecentIncidents,
+  controller.getIncidents,
 );
 
 router.param('id', controller.loadIncident);


### PR DESCRIPTION
You should now have access to all of the incidents records instead of being limited to 1000, and paging and sorting should now happen server-side. If you run a search, paging and sorting should still function as expected.

![selection_141](https://user-images.githubusercontent.com/3220897/51941794-52247e00-23ca-11e9-8a58-8aca1b9d91fc.png)
