### PR TITLE
Incidents page responsiveness overhaul.

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -70,6 +70,10 @@ import percentChange from '../components/percent-change/percent-change.component
 import rank from '../components/rank/rank.component';
 import modal from '../components/modal/modal.service';
 import shift from '../components/shift/shift.component';
+import onEnterPressed from '../components/on-enter-pressed/onEnterPressed.directive';
+import loadingSpinner from '../components/loading-spinner/loading-spinner.component';
+import loadingOverlay from '../components/loading-overlay/loading-overlay.component';
+import tableControls from '../components/table-controls/table-controls.component';
 
 import statsTable from '../components/tables/stats-table.component';
 import safety from '../components/safety/safety.component';
@@ -154,6 +158,10 @@ angular.module('statEngineApp', [
   nfpaAnalysis,
   bulletChart,
   rank,
+  onEnterPressed,
+  loadingSpinner,
+  loadingOverlay,
+  tableControls,
 ])
   .config(routeConfig)
   .config((appConfig, amplitudeConfig) => {

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -1,4 +1,28 @@
 /////////////////////////////////
+// VARIABLES //
+////////////////////////////////
+$color-cerulean:                #00A9DA;
+$color-pacific-blue:            #0099c2;
+$color-bondi-blue:              #16a2b3;
+$color-java:                    #1fc8a7;
+$color-pickled-bluewood:        #334A56;
+$color-pale-sky:                #697983;
+$color-cloudy-sky:              #abbecb;
+$color-oxford-blue:             #384553;
+$color-geyser:                  #D7DEE3;
+$color-brand-success:           #30b370;
+$color-brand-danger:            #d61745;
+$color-porcelain:               #f5f7f8;
+$color-tulip-tree:              #efb93d;
+$color-wisteria:                #9068bc;
+$color-di-serria:               #e09061;
+$color-pelorous:                #46a0c1;
+$color-cranberry:               #d6527e;
+$color-celery:                  #99c550;
+
+$primary: $color-cerulean;
+
+/////////////////////////////////
 // IMPORTS //
 ////////////////////////////////
 $fa-font-path: '/assets/fonts/font-awesome/';
@@ -25,27 +49,6 @@ $ionicons-font-path: '/assets/fonts/Ionicons/';
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:Extra-Light,Light,Regular,Medium,Semi-Bold,Bold,Extra-Bold");
 @import url('https://rsms.me/inter/inter-ui.css');
 
-/////////////////////////////////
-// VARIABLES //
-////////////////////////////////
-$color-cerulean:                #00A9DA;
-$color-pacific-blue:            #0099c2;
-$color-bondi-blue:              #16a2b3;
-$color-java:                    #1fc8a7;
-$color-pickled-bluewood:        #334A56;
-$color-pale-sky:                #697983;
-$color-cloudy-sky:              #abbecb;
-$color-oxford-blue:             #384553;
-$color-geyser:                  #D7DEE3;
-$color-brand-success:           #30b370;
-$color-brand-danger:            #d61745;
-$color-porcelain:               #f5f7f8;
-$color-tulip-tree:              #efb93d;
-$color-wisteria:                #9068bc;
-$color-di-serria:               #e09061;
-$color-pelorous:                #46a0c1;
-$color-cranberry:               #d6527e;
-$color-celery:                  #99c550;
 /////////////////////////////////
 // BROWSER //
 ////////////////////////////////
@@ -335,11 +338,23 @@ ol.statengine li::before {
   }
 }
 
+@mixin form-control-sm() {
+  height: calc(1.8125rem + 2px);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0.2rem;
+}
+
 .form-control {
   &:focus {
     border-color: $color-bondi-blue;
     box-shadow: 0 0 9px 0.2rem rgba(24, 162, 178, 0.2);
   }
+}
+
+.form-control-sm {
+  @include form-control-sm;
 }
 
 .form-extras {
@@ -669,6 +684,11 @@ button {
   letter-spacing: 0.015em;
   outline: none;
   transition: all 0.15s ease;
+
+  &:disabled, &.disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
 }
 
 // Button Types
@@ -685,7 +705,6 @@ button {
 }
 
 .btn-primary {
-  background: $color-cerulean;
   background: linear-gradient(343deg, $color-cerulean 0%, $color-java 100%);
   text-shadow: 0 1px 3px rgba(0, 151, 175, 0.5);
   border: none;
@@ -741,10 +760,6 @@ button {
   &:hover {
     background: darken($color-brand-danger, 5%);
   }
-}
-
-.btn.disabled {
-  cursor: default;
 }
 
 .btn-outline {
@@ -815,6 +830,14 @@ button {
 }
 
 // Button Sizes
+$btn-sm-font-size: 13px;
+$btn-sm-padding: 6px 12px;
+
+@mixin btn-sm() {
+  padding: 6px 12px !important;
+  font-size: 13px !important;
+}
+
 .btn {
   padding: 10px 26px;
 }
@@ -1072,7 +1095,7 @@ Adapted from: http://blog.heyimcat.com/universal-signup-form/ */
 }
 
 .br-pagebody {
-  margin-bottom: 1.5rem;
+  padding-bottom: 5.5rem !important;
 }
 
 .br-logo {
@@ -1373,4 +1396,7 @@ span+.logged-name {
 @import '../components/percent-change/percent-change';
 @import '../components/bar-gauge/bar-gauge';
 @import '../components/sidebar/sidebar';
+@import '../components/loading-spinner/loading-spinner';
+@import '../components/loading-overlay/loading-overlay';
+@import '../components/table-controls/table-controls';
 // endinject //

--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -47,7 +47,6 @@ export default class IncidentSearchController {
         this.sortColumns = this.sortColumns.slice(0, 1);
         this.sortSelect.selectedColumn = this.sortColumns[0];
         this.updateUiGridSort();
-        this.refreshIncidentsList();
       }
     });
 
@@ -118,8 +117,7 @@ export default class IncidentSearchController {
   }
 
   async $onInit() {
-    await this.refreshIncidentsList();
-    this.updateUiGridSort();
+    this.refreshIncidentsList();
   }
 
   getIncidentColumn(incident, columnDef) {
@@ -200,7 +198,6 @@ export default class IncidentSearchController {
   handleSortChange(args) {
     this.sortColumns = [args.sort.selectedColumn];
     this.updateUiGridSort();
-    this.refreshIncidentsList();
   }
 
   updateUiGridSort() {

--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -110,6 +110,11 @@ export default class IncidentSearchController {
     this.sortSelect.columnDefs = this.uiGridOptions.columnDefs.filter((columnDef) => {
       return (_.isUndefined(columnDef.enableSorting) || columnDef.enableSorting);
     });
+
+    this.refreshIncidentsList = _.debounce(this.refreshIncidentsList, 350, {
+      leading: true,
+      trailing: true,
+    });
   }
 
   async $onInit() {

--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -2,29 +2,61 @@
 
 'use strict';
 
-let _;
+import angular from 'angular';
+import _ from 'lodash';
 
 export default class IncidentSearchController {
-  page = 1;
-  pageSize = 100;
-  sort;
+  incidents = [];
+  pagination = {
+    page: 1,
+    pageSize: 100,
+    pageSizes: [10, 25, 50, 100],
+    totalItems: 0,
+  };
+  sortColumns = [{
+    field: 'description.event_closed',
+    direction: 'desc',
+  }];
+  sortSelect = {
+    selectedColumn: this.sortColumns[0],
+    columnDefs: [],
+  };
   search;
   searchInputValue;
   isLoading = true;
+  isLoadingFirst = true;
+  uiGridOptions;
   uiGridApi;
 
   /*@ngInject*/
-  constructor($scope, AmplitudeService, AnalyticEventNames, Incident) {
+  constructor($window, $scope, $filter, AmplitudeService, AnalyticEventNames, Incident) {
+    this.$window = $window;
+    this.$filter = $filter;
     this.IncidentService = Incident;
     this.AmplitudeService = AmplitudeService;
     this.AnalyticEventNames = AnalyticEventNames;
 
+    // Set a smaller default page size on mobile.
+    if($window.innerWidth <= 1200) {
+      this.pagination.pageSize = this.pagination.pageSizes[1];
+    }
+
+    angular.element($window).bind('resize', () => {
+      // Mobile only supports sorting by 1 column, so enforce this on resize to mobile.
+      if($window.innerWidth <= 1200 && this.sortColumns.length > 1) {
+        this.sortColumns = this.sortColumns.slice(0, 1);
+        this.sortSelect.selectedColumn = this.sortColumns[0];
+        this.updateUiGridSort();
+        this.refreshIncidentsList();
+      }
+    });
+
     this.uiGridOptions = {
-      data: [],
-      paginationPageSizes: [10, 25, 50, 100],
-      paginationPageSize: this.pageSize,
-      paginationCurrentPage: this.page,
-      totalItems: 0,
+      data: this.incidents,
+      paginationPageSizes: this.pagination.pageSizes,
+      paginationPageSize: this.pagination.pageSize,
+      paginationCurrentPage: this.pagination.page,
+      totalItems: this.pagination.totalItems,
       columnDefs: [{
         field: 'description.incident_number',
         displayName: 'Incident Number',
@@ -35,16 +67,19 @@ export default class IncidentSearchController {
       }, {
         field: 'description.event_closed',
         displayName: 'Event Closed',
-        cellFilter: 'date:"MMM d, y HH:mm:ss"'
+        cellFilter: 'date:"MMM d, y HH:mm:ss"',
+        defaultSort: {
+          direction: 'desc',
+          priority: 0,
+        },
       }, {
         field: 'durations.total_event.seconds',
         displayName: 'Event Duration',
         cellFilter: 'humanizeDuration',
       }, {
-        field: 'description.units',
+        field: 'description.units_count',
         displayName: '# Units',
         width: 100,
-        cellTemplate: '<div class="ui-grid-cell-contents">{{ grid.getCellValue(row, col ).length }}</div>',
         enableSorting: false,
       }, {
         field: 'description.category',
@@ -54,60 +89,92 @@ export default class IncidentSearchController {
         field: 'description.type',
         displayName: 'Type',
       }],
+      enablePaginationControls: false,
       useExternalPagination: true,
       useExternalSorting: true,
       enableHorizontalScrollbar: false,
       onRegisterApi: (uiGridApi) => {
         this.uiGridApi = uiGridApi;
-        uiGridApi.pagination.on.paginationChanged($scope, (newPage, pageSize) => { this.paginationChanged(newPage, pageSize) });
-        uiGridApi.core.on.sortChanged($scope, (uiGrid, sortColumns) => { this.sortChanged(uiGrid, sortColumns); });
+        uiGridApi.core.on.sortChanged($scope, (uiGrid, sortColumns) => {
+          this.sortColumns = sortColumns.map((sortColumn) => ({
+            field: sortColumn.field,
+            direction: sortColumn.sort.direction,
+          }));
+          this.sortSelect.selectedColumn = this.sortColumns[0];
+          this.refreshIncidentsList();
+        });
       },
     };
-  }
 
-  async loadModules() {
-    _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
+    // In sort select only show columns with sorting enabled.
+    this.sortSelect.columnDefs = this.uiGridOptions.columnDefs.filter((columnDef) => {
+      return (_.isUndefined(columnDef.enableSorting) || columnDef.enableSorting);
+    });
   }
 
   async $onInit() {
-    await this.loadModules();
-    this.refreshIncidentsList();
+    await this.refreshIncidentsList();
+    this.updateUiGridSort();
   }
 
-  paginationChanged(newPage, pageSize) {
-    this.page = newPage;
-    this.pageSize = pageSize;
-    this.refreshIncidentsList();
-  }
-
-  sortChanged(uiGrid, sortColumns) {
-    if(sortColumns.length > 0) {
-      this.sort = sortColumns.map(column => {
-        return `${column.field},${column.sort.direction}`;
-      }).join('+');
-    } else {
-      this.sort = undefined;
+  getIncidentColumn(incident, columnDef) {
+    // Translate incident field string into the incident data (ex. 'description.units.length' -> `incident['description']['units']['length']).
+    const fieldParts = columnDef.field.split('.');
+    let value = incident;
+    for(const part of fieldParts) {
+      value = value[part];
     }
-    this.refreshIncidentsList();
+
+    // Apply filter if the column def has one.
+    if(columnDef.cellFilter) {
+      const filterType = columnDef.cellFilter.split(':')[0];
+      const filterExpression = columnDef.cellFilter.match(/(?<=")(.*)(?=")/g);
+      value = this.$filter(filterType)(value, filterExpression);
+    }
+
+    return value;
+  }
+
+  getIncidentUiSref(incident) {
+    return `site.incident.analysis({ id: '${incident.description.incident_number}' })`;
   }
 
   async refreshIncidentsList() {
-    this.uiGridOptions.data = [];
     this.isLoading = true;
 
+    const sort = this.sortColumns.map((sortColumn) => {
+      return `${sortColumn.field},${sortColumn.direction}`;
+    }).join('+');
+
     const data = await this.IncidentService.get({
-      count: this.pageSize,
-      from: (this.page - 1) * this.pageSize,
-      sort: this.sort,
+      count: this.pagination.pageSize,
+      from: (this.pagination.page - 1) * this.pagination.pageSize,
+      sort,
       search: this.search,
     }).$promise;
-    this.uiGridOptions.data = data.items.map(item => item._source);
-    this.uiGridOptions.totalItems = data.totalItems;
+    this.incidents = data.items.map(item => item._source);
+    this.pagination.totalItems = data.totalItems;
+
+    // Compute 'unitCount' from 'units'.
+    this.incidents.forEach((incident) => {
+      incident.description.units_count = incident.description.units.length;
+    });
+
+    // Update uiGrid.
+    this.uiGridOptions.data = this.incidents;
+    this.uiGridOptions.totalItems = this.pagination.totalItems;
 
     this.isLoading = false;
+    this.isLoadingFirst = false;
+
+    // On mobile, automaticallys scroll back to the top on data refresh.
+    if(this.$window.innerWidth <= 1200) {
+      const page = angular.element('html')[0];
+      page.scrollTop = 0;
+    }
   }
 
-  async searchButtonClick() {
+  searchButtonClick() {
     this.AmplitudeService.track(this.AnalyticEventNames.APP_ACTION, {
       app: 'Incident Analysis',
       action: 'search',
@@ -119,5 +186,20 @@ export default class IncidentSearchController {
     }
     this.search = search;
     this.refreshIncidentsList();
+  }
+
+  handlePaginationChange() {
+    this.refreshIncidentsList();
+  }
+
+  handleSortChange(args) {
+    this.sortColumns = [args.sort.selectedColumn];
+    this.updateUiGridSort();
+    this.refreshIncidentsList();
+  }
+
+  updateUiGridSort() {
+    const gridColumn = this.uiGridApi.grid.getColumn(this.sortColumns[0].field);
+    this.uiGridApi.grid.sortColumn(gridColumn, this.sortColumns[0].direction);
   }
 }

--- a/client/app/incident/incident-search/incident-search.html
+++ b/client/app/incident/incident-search/incident-search.html
@@ -14,27 +14,98 @@
   <div class="br-pagetitle d-flex justify-content-between flex-wrap">
     <h2 class="m-0">Incidents</h2>
     <div class="input-group wd-300">
-      <input ng-model="vm.searchInputValue" type="text" class="form-control" placeholder="Search Incidents">
+      <input
+        class="form-control"
+        type="text"
+        placeholder="Search Incidents"
+        ng-model="vm.searchInputValue"
+        on-enter-pressed="vm.searchButtonClick()"
+      >
       <span class="input-group-btn">
-        <button class="btn bd-0 btn-secondary py-2 px-3 rounded-0" type="button" ng-click="vm.searchButtonClick()"><i class="fa fa-search"></i></button>
+        <button
+          class="btn bd-0 btn-primary py-2 px-3 rounded-0"
+          type="button"
+          ng-click="vm.searchButtonClick()"
+        >
+          <i class="fa fa-search"></i>
+        </button>
       </span>
     </div>
   </div><!-- br-pagetitle -->
   <div class="br-pagebody">
-    <section class="br-section-wrapper shadow-none pd-0">
-      <div class="incidents-desktop search-grid" ui-grid="vm.uiGridOptions" ui-grid-pagination ui-grid-resize-column>
-        <h2
-          class="watermark heavyheader text-muted"
-          ng-show="!vm.isLoading && !vm.uiGridOptions.data.length"
+    <section>
+      <!-- Incidents (desktop) -->
+      <div class="incidents-desktop hidden-lg-down">
+        <div
+          class="search-grid"
+          ui-grid="vm.uiGridOptions"
+          ui-grid-resize-column
         >
-          No data available
-        </h2>
-        <h2
-          class="watermark heavyheader text-muted"
-          ng-show="vm.isLoading"
-        >
-          Loading...
-        </h2>
+          <loading-overlay ng-if="vm.isLoading" show-spinner="true"></loading-overlay>
+          <h2
+            class="watermark heavyheader text-muted"
+            ng-show="!vm.isLoading && !vm.uiGridOptions.data.length"
+          >
+            No data available
+          </h2>
+        </div>
+
+        <table-controls
+          pagination="vm.pagination"
+          on-pagination-change="vm.handlePaginationChange({ pagination })"
+          position="bottom"
+          show-sort="false"
+        ></table-controls>
+      </div>
+
+      <!-- Incidents (mobile) -->
+      <div class="incidents-mobile hidden-xl-up">
+        <table-controls
+          pagination="vm.pagination"
+          sort="vm.sortSelect"
+          on-pagination-change="vm.handlePaginationChange({ pagination })"
+          on-sort-change="vm.handleSortChange({ sort })"
+          is-loading="vm.isLoading"
+          position="top"
+        ></table-controls>
+
+        <!-- Incidents table -->
+        <div class="incidents-mobile-table">
+          <loading-overlay ng-if="vm.isLoading" show-spinner="false"></loading-overlay>
+
+          <div
+            class="table-row"
+            ng-repeat="incident in vm.incidents"
+          >
+            <div
+              class="cell"
+              ng-repeat="columnDef in vm.uiGridOptions.columnDefs"
+              ng-attr-data-title="{{ columnDef.displayName }}"
+            >
+              <a
+                ng-if="columnDef.field === 'description.incident_number'"
+                ng-attr-ui-sref="{{ vm.getIncidentUiSref(incident) }}"
+                href="#"
+              >
+                {{ vm.getIncidentColumn(incident, columnDef) }}
+              </a>
+
+              <span ng-if="columnDef.field !== 'description.incident_number'">
+                {{ vm.getIncidentColumn(incident, columnDef) }}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <table-controls
+          ng-if="!vm.isLoadingFirst"
+          pagination="vm.pagination"
+          sort="vm.sortSelect"
+          on-pagination-change="vm.handlePaginationChange({ pagination })"
+          on-sort-change="vm.handleSortChange({ sort })"
+          is-loading="vm.isLoading"
+          position="bottom"
+        ></table-controls>
       </div>
     </section>
   </div>

--- a/client/app/incident/incident-search/incident-search.scss
+++ b/client/app/incident/incident-search/incident-search.scss
@@ -1,0 +1,14 @@
+.incident-search {
+  .incidents-desktop {
+    .search-grid {
+      height: 61vh;
+    }
+  }
+
+  .incidents-mobile {
+    .incidents-mobile-table {
+      @include table($max-width: 1200px);
+      position: relative;
+    }
+  }
+}

--- a/client/app/incident/incident.scss
+++ b/client/app/incident/incident.scss
@@ -1,3 +1,5 @@
+@import 'incident-search/incident-search.scss';
+
 // Baseline style for statistical units found in the card layout
 .stat {
     align-items: center;
@@ -282,10 +284,6 @@ circle.blue-dot {
 
 .indent-1 {
     text-indent: 1em;
-}
-
-.search-grid {
-    height: 65vh;
 }
 
 // Override Plot.ly JS

--- a/client/components/loading-overlay/loading-overlay.component.html
+++ b/client/components/loading-overlay/loading-overlay.component.html
@@ -1,0 +1,2 @@
+
+<loading-spinner ng-if="vm.showSpinner" ng-style="vm.spinnerStyle"></loading-spinner>

--- a/client/components/loading-overlay/loading-overlay.component.js
+++ b/client/components/loading-overlay/loading-overlay.component.js
@@ -1,0 +1,31 @@
+'use strict';
+
+import angular from 'angular';
+
+export class LoadingOverlayController {
+  spinnerSize;
+  showSpinner;
+  spinnerStyle;
+
+  $onInit() {
+    this.spinnerSize = this.spinnerSize || 80;
+    this.showSpinner = (!_.isUndefined(this.showSpinner)) ? this.showSpinner : true;
+
+    this.spinnerStyle = {
+      width: `${this.spinnerSize}px`,
+      height: `${this.spinnerSize}px`,
+    };
+  }
+}
+
+export default angular.module('loadingOverlay', [])
+  .component('loadingOverlay', {
+    template: require('./loading-overlay.component.html'),
+    controller: LoadingOverlayController,
+    controllerAs: 'vm',
+    bindings: {
+      spinnerSize: '<?',
+      showSpinner: '<?',
+    },
+  })
+  .name

--- a/client/components/loading-overlay/loading-overlay.scss
+++ b/client/components/loading-overlay/loading-overlay.scss
@@ -1,0 +1,11 @@
+loading-overlay {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.35);
+}

--- a/client/components/loading-spinner/loading-spinner.component.html
+++ b/client/components/loading-spinner/loading-spinner.component.html
@@ -1,0 +1,2 @@
+
+<div class="spinner"></div>

--- a/client/components/loading-spinner/loading-spinner.component.js
+++ b/client/components/loading-spinner/loading-spinner.component.js
@@ -1,0 +1,9 @@
+'use strict';
+
+import angular from 'angular';
+
+export default angular.module('loadingSpinner', [])
+  .component('loadingSpinner', {
+    template: require('./loading-spinner.component.html'),
+  })
+  .name

--- a/client/components/loading-spinner/loading-spinner.scss
+++ b/client/components/loading-spinner/loading-spinner.scss
@@ -1,0 +1,29 @@
+loading-spinner {
+  width: 40px;
+  height: 40px;
+  display: inline-block;
+
+  .spinner {
+    width: 100%;
+    height: 100%;
+    border: solid 2px transparent;
+    border-top-color: #29d;
+    border-left-color: #29d;
+    border-radius: 50%;
+    -webkit-animation: spin 400ms linear infinite;
+    -moz-animation: spin 400ms linear infinite;
+    -ms-animation: spin 400ms linear infinite;
+    -o-animation: spin 400ms linear infinite;
+    animation: spin 400ms linear infinite;
+
+    @keyframes spin {
+      0% {
+        transform: rotateZ(0);
+      }
+
+      100% {
+        transform: rotateZ(360deg);
+      }
+    }
+  }
+}

--- a/client/components/on-enter-pressed/onEnterPressed.directive.js
+++ b/client/components/on-enter-pressed/onEnterPressed.directive.js
@@ -1,0 +1,26 @@
+'use strict';
+
+import angular from 'angular';
+
+export default angular.module('onEnterPressed', [])
+  .directive('onEnterPressed', () => {
+    return {
+      restrict: 'A',
+      link: (scope, element, attrs) => {
+        element.bind("keypress", (event) => {
+          const keyCode = event.which || event.keyCode;
+
+          // If enter key is pressed...
+          if(keyCode === 13) {
+            scope.$apply(() => {
+              // Evaluate the expression.
+              scope.$eval(attrs.onEnterPressed);
+            });
+
+            event.preventDefault();
+          }
+        });
+      },
+    };
+  })
+  .name

--- a/client/components/table-controls/table-controls.component.html
+++ b/client/components/table-controls/table-controls.component.html
@@ -1,0 +1,85 @@
+
+<div
+  class="root"
+  ng-class="{
+    'position-top': (vm.position === 'top'),
+    'position-bottom': (vm.position === 'bottom')
+  }"
+>
+  <div class="column-one">
+    <div class="page-control">
+      <div class="form-inline position-relative d-inline-flex">
+        <button
+          class="btn btn-primary"
+          ng-click="vm.prevButtonClick()"
+          ng-disabled="vm.pagination.page === 1"
+        >
+          Previous
+        </button>
+        <span class="page-number">
+          <select
+            class="page-number-select form-control"
+            ng-model="vm.pageGetterSetter"
+            ng-model-options="{ getterSetter: true }"
+          >
+            <option
+              ng-repeat="pageNumber in vm.pageNumbers"
+              ng-value="pageNumber"
+            >
+              {{ pageNumber }}
+            </option>
+          </select>
+          <span>/ {{ vm.totalPages }}</span>
+        </span>
+        <button
+          class="btn btn-primary"
+          ng-click="vm.nextButtonClick()"
+          ng-disabled="vm.pagination.page === vm.pageNumbers.slice(-1)[0]"
+        >
+          Next
+        </button>
+        <loading-spinner ng-if="vm.isLoading"></loading-spinner>
+      </div>
+    </div>
+  </div>
+
+  <div class="column-two">
+    <div class="sort-control" ng-if="vm.showSort">
+      <div class="form-inline flex-nowrap">
+        <span class="space-nowrap">Sort by:&nbsp;</span>
+        <select
+          class="sort-select form-control"
+          ng-model="vm.sortGetterSetter"
+          ng-model-options="{ getterSetter: true }"
+        >
+          <option
+            ng-repeat="columnDef in vm.columnDefs"
+            ng-value="vm.sortColumnToValue(columnDef)"
+          >
+            {{ columnDef.displayName }}
+          </option>
+        </select>
+      </div>
+    </div>
+
+    <div class="page-size-control">
+      <div class="form-inline flex-nowrap">
+        <div class="space-nowrap">Items per page:&nbsp;</div>
+        <select
+          class="page-size-select form-control"
+          ng-model="vm.pageSizeGetterSetter"
+          ng-model-options="{ getterSetter: true }"
+        >
+          <option
+            ng-repeat="pageSize in vm.pagination.pageSizes"
+            ng-value="pageSize"
+          >
+            {{ pageSize }}
+          </option>
+        </select>
+      </div>
+    </div>
+  </div>
+</div>
+
+

--- a/client/components/table-controls/table-controls.component.js
+++ b/client/components/table-controls/table-controls.component.js
@@ -61,7 +61,13 @@ export class TableControlsController {
     if(_.isUndefined(value)) {
       return this.pagination.pageSize;
     } else {
+      const prevPageSize = this.pagination.pageSize;
       this.pagination.pageSize = value;
+
+      // Recalculate current page to maintain position.
+      const pageFirstItemIndex = this.pagination.page * prevPageSize - prevPageSize;
+      this.pagination.page = 1 + Math.floor(pageFirstItemIndex / this.pagination.pageSize);
+
       this.fireOnPaginationChange();
     }
   }

--- a/client/components/table-controls/table-controls.component.js
+++ b/client/components/table-controls/table-controls.component.js
@@ -1,0 +1,128 @@
+'use strict';
+
+import angular from 'angular';
+import _ from 'lodash';
+
+export class TableControlsController {
+  pagination;
+  sort;
+  onPaginationChange;
+  onSortChange;
+  isLoading;
+  position;
+  showSort;
+  columnDefs = [];
+
+  $onInit() {
+    this.sort = this.sort || {
+      selectedColumn: null,
+      columnDefs: [],
+    };
+    this.onPaginationChange = this.onPaginationChange || (()=>{});
+    this.onSortChange = this.onSortChange || (()=>{});
+    this.position = this.position || 'bottom';
+    this.showSort = (!_.isUndefined(this.showSort)) ? this.showSort : true;
+
+    // Generate ascending/descending sort options.
+    const generatedColumnDefs = [];
+    this.sort.columnDefs.forEach((columnDef) => {
+      generatedColumnDefs.push({
+        displayName: `${columnDef.displayName} (ASC)`,
+        field: columnDef.field,
+        direction: 'asc',
+      });
+      generatedColumnDefs.push({
+        displayName: `${columnDef.displayName} (DESC)`,
+        field: columnDef.field,
+        direction: 'desc',
+      });
+    });
+    this.columnDefs = generatedColumnDefs;
+  }
+
+  get totalPages() {
+    return Math.ceil(this.pagination.totalItems / this.pagination.pageSize);
+  }
+
+  get pageNumbers() {
+    return _.range(1, this.totalPages + 1);
+  }
+
+  pageGetterSetter(value) {
+    if(_.isUndefined(value)) {
+      return this.pagination.page;
+    } else {
+      this.pagination.page = value || 1;
+      this.fireOnPaginationChange();
+    }
+  }
+
+  pageSizeGetterSetter(value) {
+    if(_.isUndefined(value)) {
+      return this.pagination.pageSize;
+    } else {
+      this.pagination.pageSize = value;
+      this.fireOnPaginationChange();
+    }
+  }
+
+  prevButtonClick() {
+    if(this.pagination.page === 1) {
+      return;
+    }
+
+    this.pagination.page--;
+    this.fireOnPaginationChange();
+  }
+
+  nextButtonClick() {
+    if(this.pagination.page === this.totalPages) {
+      return;
+    }
+
+    this.pagination.page++;
+    this.fireOnPaginationChange();
+  }
+
+  fireOnPaginationChange() {
+    this.onPaginationChange({ pagination: this.pagination });
+  }
+
+  sortGetterSetter(value) {
+    if(_.isUndefined(value)) {
+      return (this.sort.selectedColumn) ? this.sortColumnToValue(this.sort.selectedColumn) : undefined;
+    } else {
+      this.sort.selectedColumn = this.sortValueToColumn(value);
+      this.onSortChange({ sort: this.sort });
+    }
+  }
+
+  sortColumnToValue(sortColumn) {
+    return `${sortColumn.field},${sortColumn.direction}`;
+  }
+
+  sortValueToColumn(sortString) {
+    const parts = sortString.split(',');
+    return {
+      field: parts[0],
+      direction: parts[1],
+    };
+  }
+}
+
+export default angular.module('tableControls', [])
+  .component('tableControls', {
+    template: require('./table-controls.component.html'),
+    controller: TableControlsController,
+    controllerAs: 'vm',
+    bindings: {
+      pagination: '=',
+      sort: '=?',
+      onPaginationChange: '&?',
+      onSortChange: '&?',
+      isLoading: '<?',
+      position: '@?',
+      showSort: '<?',
+    },
+  })
+  .name;

--- a/client/components/table-controls/table-controls.scss
+++ b/client/components/table-controls/table-controls.scss
@@ -1,0 +1,150 @@
+table-controls {
+  button {
+    @include media-breakpoint-down(xs) {
+      @include btn-sm();
+    }
+  }
+
+  loading-spinner {
+    position: absolute;
+    right: -2rem;
+    transform: translateX(100%);
+
+    @include media-breakpoint-down(xs) {
+      width: 30px;
+      height: 30px;
+    }
+  }
+
+  .root {
+    display: flex;
+    flex-direction: row;
+
+    @include media-breakpoint-down(sm) {
+      flex-direction: column;
+    }
+  }
+
+  .column-one {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
+  .column-two {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    flex: 0;
+
+    @include media-breakpoint-down(sm) {
+      align-items: flex-start;
+    }
+  }
+
+  .page-control {
+    .page-number {
+      margin: 0 1rem;
+
+      .page-number-select {
+        display: inline-block !important;
+        width: auto !important;
+        vertical-align: middle !important;
+
+        @include media-breakpoint-down(xs) {
+          @include form-control-sm();
+        }
+      }
+    }
+  }
+
+  .sort-control {
+    display: inline-block;
+
+    .sort-select {
+      display: inline-block !important;
+      width: auto !important;
+      vertical-align: middle !important;
+
+      @include media-breakpoint-down(xs) {
+        @include form-control-sm();
+      }
+    }
+  }
+
+  .page-size-control {
+    .page-size-select {
+      display: inline-block !important;
+      width: auto !important;
+      vertical-align: middle !important;
+
+      @include media-breakpoint-down(xs) {
+        @include form-control-sm();
+      }
+    }
+  }
+
+  .position-top {
+    margin-bottom: 1rem;
+
+    .column-one {
+      justify-content: flex-end;
+
+      @include media-breakpoint-down(sm) {
+        order: 2;
+      }
+    }
+
+    .column-two {
+      @include media-breakpoint-down(sm) {
+        order: 1;
+      }
+    }
+
+    .sort-control {
+      order: 1;
+      margin-bottom: 1rem;
+    }
+
+    .page-size-control {
+      order: 2;
+
+      @include media-breakpoint-down(sm) {
+        margin-bottom: 1rem;
+      }
+    }
+  }
+
+  .position-bottom {
+    margin-top: 1rem;
+
+    .column-one {
+      justify-content: flex-start;
+
+      @include media-breakpoint-down(sm) {
+        order: 1;
+      }
+    }
+
+    .column-two {
+      @include media-breakpoint-down(sm) {
+        order: 2;
+      }
+    }
+
+    .page-control {
+      @include media-breakpoint-down(sm) {
+        margin-bottom: 1rem;
+      }
+    }
+
+    .page-size-control {
+      order: 1;
+      margin-bottom: 1rem;
+    }
+
+    .sort-control {
+      order: 2;
+    }
+  }
+}

--- a/server/api/incident/incident.controller.js
+++ b/server/api/incident/incident.controller.js
@@ -105,7 +105,7 @@ export function getSummary(req, res) {
     .then(results => res.json(results));
 }
 export function getIncidents(req, res) {
-  const sort = req.query.sort || 'description.event_opened,desc';
+  const sort = req.query.sort || 'description.event_closed,desc';
 
   const params = {
     index: req.user.FireDepartment.get().es_indices['fire-incident'],


### PR DESCRIPTION
Added a custom table view for mobile, custom pagination and sorting controls, as well as loading indicators. The search input should now submit when you press enter with it focused. You should be able to clearly see all data on all screen widths.

For the sake of simplicity, I limited mobile to only sorting by a single column, whereas the desktop view allows you to sort by multiple columns. We could potentially make the mobile sort selector expand dynamically to allow multiple column sorting, but it doesn't seem worth the effort at the moment.

### Desktop
![selection_144](https://user-images.githubusercontent.com/3220897/52406385-70514480-2a82-11e9-8eea-b4330059c7cc.png)

### Mobile
![selection_145](https://user-images.githubusercontent.com/3220897/52406393-73e4cb80-2a82-11e9-8b92-2ab50977c8a5.png)
