### PR TITLE
Fix incident map default zoom level.

### DIFF
--- a/client/components/incident/incident-map.component.js
+++ b/client/components/incident/incident-map.component.js
@@ -64,9 +64,14 @@ export default class IncidentMapComponent {
         }
       });
 
-      map.fitBounds(bounds, {
-        padding: 20
-      });
+      // Apply padding manually since MapBoxGL seems to be a bit glitchy here.
+      const padding = 0.0015;
+      bounds[0] -= padding;
+      bounds[1] -= padding;
+      bounds[2] += padding;
+      bounds[3] += padding;
+
+      map.fitBounds(bounds);
     });
   }
 }


### PR DESCRIPTION
### Before
<img width="1171" alt="screen shot 2019-02-08 at 5 08 52 am" src="https://user-images.githubusercontent.com/3220897/52480115-a7495800-2b5f-11e9-8f4b-715570d46bc8.png">

### After
<img width="1173" alt="screen shot 2019-02-08 at 5 07 56 am" src="https://user-images.githubusercontent.com/3220897/52480065-87199900-2b5f-11e9-886e-973aa4f6aae0.png">
