### PR TITLE
More consistent and improved table styling.

### DIFF
--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -217,7 +217,11 @@ table td {
     display: table-row;
 
     &:nth-of-type(even) {
-      background: lighten($color-geyser, 10%);
+      background: $color-porcelain;
+    }
+
+    &:nth-of-type(odd) {
+      background: white;
     }
 
     &.header {
@@ -246,8 +250,8 @@ table td {
           line-height: 13px;
           font-weight: bold;
           text-transform: uppercase;
-          color: darken($color-geyser, 15%);
           display: block;
+          color: #adb2b7;
         }
       }
     }

--- a/client/app/incident/incident-search/incident-search.scss
+++ b/client/app/incident/incident-search/incident-search.scss
@@ -2,6 +2,25 @@
   .incidents-desktop {
     .search-grid {
       height: 61vh;
+
+      .ui-grid-top-panel {
+        background-color: white;
+        color: #adb2b7;
+        text-transform: uppercase;
+        font-size: 12px;
+
+        .ui-grid-cell-contents {
+          padding: 10px;
+        }
+      }
+
+      .ui-grid-row:nth-child(odd):not(:hover) .ui-grid-cell {
+        background-color: $color-porcelain;
+      }
+
+      .ui-grid-row:nth-child(even):not(:hover) .ui-grid-cell {
+        background-color: white;
+      }
     }
   }
 


### PR DESCRIPTION
I mainly just made the Incidents table header match the styling of other tables. But I also tweaked the row coloring on tables slightly since before the darker rows matched the background exactly. They're slightly lighter now so that they stand out a bit better from the background. It mainly helps in the mobile view with the cards.

### Before
<img width="1177" alt="screen shot 2019-02-09 at 4 09 42 am" src="https://user-images.githubusercontent.com/3220897/52520676-db388200-2c20-11e9-8920-24ee53484cc1.png">

### After
<img width="1180" alt="screen shot 2019-02-09 at 4 10 04 am" src="https://user-images.githubusercontent.com/3220897/52520678-df649f80-2c20-11e9-93de-9ee4329329be.png">
