### PR TITLE
Automatically hide mobile navbar on page change.

### DIFF
--- a/client/components/sidebar/sidebar.component.js
+++ b/client/components/sidebar/sidebar.component.js
@@ -5,7 +5,7 @@
 import angular from 'angular';
 
 export class SidebarComponent {
-  constructor($state, $window, AmplitudeService, AnalyticEventNames, Principal) {
+  constructor($state, $window, $transitions, AmplitudeService, AnalyticEventNames, Principal) {
     'ngInject';
 
     this.$state = $state;
@@ -20,6 +20,10 @@ export class SidebarComponent {
       }
     });
     this.PrincipalService = Principal;
+
+    $transitions.onSuccess({}, () => {
+      $('body').removeClass('show-left');
+    });
   }
 
   signout() {


### PR DESCRIPTION
On small screen sizes the navbar should now close automatically after you click on an item in the navbar.