### PR TITLE
Fix incompatible regex in Incidents page.

### DIFF
--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -130,9 +130,15 @@ export default class IncidentSearchController {
 
     // Apply filter if the column def has one.
     if(columnDef.cellFilter) {
-      const filterType = columnDef.cellFilter.split(':')[0];
-      const filterExpression = columnDef.cellFilter.match(/(?<=")(.*)(?=")/g);
-      value = this.$filter(filterType)(value, filterExpression);
+      const filterParts = columnDef.cellFilter.split(':');
+      const filterType = filterParts[0];
+      if(filterParts.length > 1) {
+        // Get the filter expression and trim the quote marks off of it.
+        const filterExpression = columnDef.cellFilter.slice(filterType.length + 1).slice(1, -1);
+        value = this.$filter(filterType)(value, filterExpression);
+      } else {
+        value = this.$filter(filterType)(value);
+      }
     }
 
     return value;


### PR DESCRIPTION
This is probably a better way to accomplish the same thing anyways, since regex is just confusing as hell to look at. You can test to make sure it's working by looking at the **Event Closed** date on the mobile view. It should look the same as in the desktop view.