### PR TITLE
Update misleading text in subscription canceled modal.

### DIFF
--- a/client/components/auth/router.decorator.js
+++ b/client/components/auth/router.decorator.js
@@ -15,6 +15,10 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
     }
   }
 
+  function getRenewSubscriptionHelpText() {
+    return `To renew your subscription, contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble (<i class="fa fa-comments"></i>) in the lower right corner.`
+  }
+
   function showSubscriptionExpiredWarning(daysSinceCancellation) {
     const daysRemaining = daysToRenewSubscription - daysSinceCancellation;
     const daysRemainingText = (daysRemaining === 1) ? `${daysRemaining} day` : `${daysRemaining} days`;
@@ -23,7 +27,7 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
       content: `
         Please renew your subscription. You have <strong>${daysRemainingText}</strong> remaining before your service will be suspended.<br/>
         <br/>
-        To renew your subscription, click "Manage Subscription" on the menu or contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble (<i class="fa fa-comments"></i>) in the lower right corner.
+        ${getRenewSubscriptionHelpText()}
       `,
       showCloseButton: false,
       enableBackdropDismiss: false,
@@ -37,7 +41,7 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
       content = `
         Your subscription renewal grace period has elapsed and service has been suspended.<br/>
         <br/>
-        To renew your subscription, click "Manage Subscription" on the menu or contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble (<i class="fa fa-comments"></i>) in the lower right corner.
+        ${getRenewSubscriptionHelpText()}
       `
     } else {
       content = "Your department's subscription has expired and service has been suspended. Please contact your department administrator to restore service.";

--- a/client/components/auth/router.decorator.js
+++ b/client/components/auth/router.decorator.js
@@ -16,7 +16,7 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
   }
 
   function getRenewSubscriptionHelpText() {
-    return `To renew your subscription, contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble (<i class="fa fa-comments"></i>) in the lower right corner.`
+    return `To renew your subscription, visit the <a href="/subscriptionPortal" target="_blank">Manage Subscription</a> page or contact us at <a href="mailto:contact@statengine.io">contact@statengine.io</a> or by using the chat bubble <span class="space-nowrap">(<i class="fa fa-comments"></i>)</span> in the lower right corner.`
   }
 
   function showSubscriptionExpiredWarning(daysSinceCancellation) {
@@ -88,19 +88,19 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
     if(subscription && subscription.status === 'cancelled') {
       const canceledAt = moment(subscription.cancelled_at * 1000);
       const daysSinceCancellation = moment().diff(canceledAt, 'days');
-      if(daysSinceCancellation < daysToRenewSubscription) {
-        if(currentPrincipal.isDepartmentAdmin) {
-          // Only show the warning once per day.
-          const shownAt = moment(parseInt($cookies.get('subscription_expiry_warning_shown_at')) || 0);
-          const daysSinceShown = moment().diff(shownAt, 'days');
-          if(daysSinceShown >= 1) {
-            showSubscriptionExpiredWarning(daysSinceCancellation);
-            $cookies.put('subscription_expiry_warning_shown_at', moment().valueOf());
-          }
-        }
-      } else {
+      // if(daysSinceCancellation < daysToRenewSubscription) {
+      //   if(currentPrincipal.isDepartmentAdmin) {
+      //     // Only show the warning once per day.
+      //     const shownAt = moment(parseInt($cookies.get('subscription_expiry_warning_shown_at')) || 0);
+      //     const daysSinceShown = moment().diff(shownAt, 'days');
+      //     if(daysSinceShown >= 1) {
+      //       showSubscriptionExpiredWarning(daysSinceCancellation);
+      //       $cookies.put('subscription_expiry_warning_shown_at', moment().valueOf());
+      //     }
+      //   }
+      // } else {
         showSubscriptionExpired();
-      }
+      // }
     }
   }
 

--- a/client/components/auth/router.decorator.js
+++ b/client/components/auth/router.decorator.js
@@ -88,19 +88,19 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
     if(subscription && subscription.status === 'cancelled') {
       const canceledAt = moment(subscription.cancelled_at * 1000);
       const daysSinceCancellation = moment().diff(canceledAt, 'days');
-      // if(daysSinceCancellation < daysToRenewSubscription) {
-      //   if(currentPrincipal.isDepartmentAdmin) {
-      //     // Only show the warning once per day.
-      //     const shownAt = moment(parseInt($cookies.get('subscription_expiry_warning_shown_at')) || 0);
-      //     const daysSinceShown = moment().diff(shownAt, 'days');
-      //     if(daysSinceShown >= 1) {
-      //       showSubscriptionExpiredWarning(daysSinceCancellation);
-      //       $cookies.put('subscription_expiry_warning_shown_at', moment().valueOf());
-      //     }
-      //   }
-      // } else {
+      if(daysSinceCancellation < daysToRenewSubscription) {
+        if(currentPrincipal.isDepartmentAdmin) {
+          // Only show the warning once per day.
+          const shownAt = moment(parseInt($cookies.get('subscription_expiry_warning_shown_at')) || 0);
+          const daysSinceShown = moment().diff(shownAt, 'days');
+          if(daysSinceShown >= 1) {
+            showSubscriptionExpiredWarning(daysSinceCancellation);
+            $cookies.put('subscription_expiry_warning_shown_at', moment().valueOf());
+          }
+        }
+      } else {
         showSubscriptionExpired();
-      // }
+      }
     }
   }
 


### PR DESCRIPTION
The issue with the text is explained here https://github.com/statengine/stat-engine/issues/189

## Before
![selection_156](https://user-images.githubusercontent.com/3220897/53780517-b353db80-3eb9-11e9-8c05-f758aef42ecf.png)

## After
![selection_155](https://user-images.githubusercontent.com/3220897/53780522-b949bc80-3eb9-11e9-9372-5b9dc7bb0d4b.png)
