### PR TITLE
Update total value on data change in chart-table component.

### DIFF
--- a/client/components/chart-table/chart-table.component.js
+++ b/client/components/chart-table/chart-table.component.js
@@ -12,6 +12,9 @@ export class ChartTableComponent {
 
   $onInit() {
     this.metricTitle = this.metricTitle || 'Count';
+  }
+
+  $onChanges() {
     this.total = _.sumBy(this.data, n => n.count);
   }
 }

--- a/client/components/chart-table/chart-table.component.js
+++ b/client/components/chart-table/chart-table.component.js
@@ -14,8 +14,10 @@ export class ChartTableComponent {
     this.metricTitle = this.metricTitle || 'Count';
   }
 
-  $onChanges() {
-    this.total = _.sumBy(this.data, n => n.count);
+  $onChanges(changes) {
+    if(changes.data) {
+      this.total = _.sumBy(this.data, n => n.count);
+    }
   }
 }
 


### PR DESCRIPTION
This fixes issue #194.

I couldn't find any simple way to test this locally without adding a bit of code, but I'm sure it will fix the problem. You can at least verify that it doesn't break the chart though.

The problem was the incident category chart was only calculating the total value the bars scale by on init, so when data would change they would be scaled by the initial total instead of the current total.