### PR TITLE
Fix bar gauge needle positioning.

### DIFF
--- a/client/components/bar-gauge/bar-gauge.component.js
+++ b/client/components/bar-gauge/bar-gauge.component.js
@@ -80,6 +80,7 @@ export class BarGaugeComponent {
     let valuePercent = 0;
     if(ranges[quartile]) {
       valuePercent = (this.value - ranges[quartile][0]) / (ranges[quartile][1] - ranges[quartile][0]) || 0;
+      valuePercent *= 100;
       this.needleGroupStyle.visibility = 'visible';
     } else {
       this.needleGroupStyle.visibility = 'hidden';


### PR DESCRIPTION
The percentage value was never being scaled up from 0-1 to 0-100, so the needles were always right near the minimum position.