### PR TITLE
Fix bar gauge needle positioning.

### DIFF
--- a/client/app/reporting/reporting-unit/reporting-unit.html
+++ b/client/app/reporting/reporting-unit/reporting-unit.html
@@ -111,9 +111,7 @@
                     data="vm.totalIncidentCounts"
                     min-label="Slow"
                     max-label="Busy"
-                    min="vm.totalIncidentMin.total_count"
-                    value="vm.currentMetrics.total_data.total_count || 0"
-                    max="vm.totalIncidentMax.total_count"
+                    value="vm.currentMetrics.total_data.total_count"
                   ></bar-gauge>
                 </div>
 

--- a/client/components/bar-gauge/bar-gauge.html
+++ b/client/components/bar-gauge/bar-gauge.html
@@ -1,6 +1,6 @@
 <div class="bar-gauge-wrapper" ng-cloak>
   <div class="meter">
-    <div class="needle-group" ng-style="vm.needleGroupStyle">
+    <div class="needle-group">
       <div class="needle-container" ng-style="vm.needleContainerStyle">
         <div class="needle-text" ng-style="vm.needleTextStyle">
           {{ vm.isDuration ? (vm.value|humanizeDuration:true) : (vm.value|number:0) }}
@@ -11,11 +11,10 @@
     </div>
 
     <div class="blocks">
-      <div></div>
-      <div></div>
-      <div></div>
-      <div></div>
-      <div></div>
+      <div
+        ng-repeat="blockStyle in vm.blockStyles"
+        ng-style="blockStyle"
+      ></div>
     </div>
 
     <div class="labels">

--- a/client/components/bar-gauge/bar-gauge.scss
+++ b/client/components/bar-gauge/bar-gauge.scss
@@ -32,15 +32,11 @@
       &:first-child {
         @extend .rounded-left;
         @extend .low;
-        margin-left: 0;
-
       }
 
       &:last-child {
         @extend .rounded-right;
         @extend .high;
-        margin-right: 0;
-
       }
     }
   }
@@ -60,7 +56,7 @@
   }
 
   .needle-group {
-    padding: 0 5px 2px;
+    padding-bottom: 2px;
 
     .needle-container {
       display: inline-block;
@@ -98,6 +94,7 @@
 .description {
   font-size: 12px;
   top: 37px;
+  padding: 0 1px;
 }
 
 .dot {


### PR DESCRIPTION
This should be the proper fix for the bar gauge needles.

I also noticed the needles would sometimes be within one category, but the text would say a different one. It was an issue with the bars all being of equal lengths when the percentile groups weren't exactly equal in length (between their min/max). I made the bars scale a bit more dynamically to exactly match their associated percentile groups. So the needles should essentially be pixel-perfect now when transitioning between categories. They're off by like a pixel right on the edge cases due to some margin weirdness with flexbox, but it didn't seem worth the additional complexity to fix that. It's already obsessively precise enough I think.

I also add a special case for when there's no range between data points, which was causing some funkiness in the percentile calculations before.