### PR TITLE
Remove unnecessary card option buttons on Incident Detail page.

### DIFF
--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -68,9 +68,6 @@
                 <div class="card h-100">
                   <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                     <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Incident Summary</h6>
-                    <div class="card-option">
-                      <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                    </div><!-- card-option -->
                   </div><!-- card-header -->
                   <div class="card-body">
                     <p class="d-flex justify-content-between mg-b-5 bd-b pd-y-5">
@@ -110,9 +107,6 @@
                 <div class="card h-100">
                   <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                     <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Dispatch Comments</h6>
-                    <div class="card-option">
-                      <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                    </div><!-- card-option -->
                   </div><!-- card-header -->
                   <div class="card-body h-100">
                     <div ng-if="!vm.incident.description.comments" class="d-flex h-100">
@@ -134,9 +128,6 @@
                 <div class="card h-100">
                   <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                     <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">StatEngine&trade; Performance Analysis</h6>
-                    <div class="card-option">
-                      <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                    </div><!-- card-option -->
                   </div><!-- card-header -->
                   <div class="card-body">
                     <div ng-show="!vm.incident.description.suppressed" class="performance-analysis">
@@ -213,9 +204,6 @@
                 <div class="card h-100">
                   <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                     <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Census Data</h6>
-                    <div class="card-option">
-                      <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                    </div><!-- card-option -->
                   </div><!-- card-header -->
                   <div class="card-body h-100">
                     <div ng-if="!vm.incident.address.location.census" class="d-flex h-100">
@@ -273,9 +261,6 @@
                 <div class="card h-100">
                   <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                     <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Parcel Data</h6>
-                    <div class="card-option">
-                      <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                    </div><!-- card-option -->
                   </div><!-- card-header -->
                   <div class="card-body h-100">
                     <div ng-if="vm.incident.address.location.parcel">
@@ -327,9 +312,6 @@
                 <div class="card h-100">
                   <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                     <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Weather Conditions</h6>
-                    <div class="card-option">
-                      <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                    </div><!-- card-option -->
                   </div><!-- card-header -->
                   <div class="card-body h-100">
                     <div ng-if="vm.incident.weather.currently">
@@ -358,9 +340,6 @@
                 <div class="card  h-100">
                   <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                     <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Traffic Conditions</h6>
-                    <div class="card-option">
-                      <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                    </div><!-- card-option -->
                   </div><!-- card-header -->
                   <div class="card-body h-100">
                     <div class="d-flex h-100 tx-center">
@@ -382,9 +361,6 @@
               <div class="card h-100 response-overview">
                 <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                   <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Overview</h6>
-                  <div class="card-option">
-                    <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                  </div><!-- card-option -->
                 </div><!-- card-header -->
                 <div class="card-body">
                   <div class="row tx-center">
@@ -417,9 +393,6 @@
               <div class="card mt-5">
                 <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
                   <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Events Timeline</h6>
-                  <div class="card-option">
-                    <a href="#"><i class="icon ion-more lh-0 tx-20"></i></a>
-                  </div><!-- card-option -->
                 </div><!-- card-header -->
                 <div class="card-body">
                   <div class="row">


### PR DESCRIPTION
There were several unused card option buttons that did nothing when clicked. I just went ahead and removed them. There were a few more further down the page that I also removed that aren't shown in the screenshot. I made sure to keep the (i) tooltips where those were used instead of the ellipsis button.

## Before
![Selection_177](https://user-images.githubusercontent.com/3220897/55261211-8334f980-5227-11e9-8f60-f654a0de27b4.png)

## After
![Selection_178](https://user-images.githubusercontent.com/3220897/55261217-88924400-5227-11e9-90c2-9e76aa3d0974.png)
