### PR TITLE
Ignore subscription expiry for global users.

### DIFF
--- a/client/components/auth/router.decorator.js
+++ b/client/components/auth/router.decorator.js
@@ -80,6 +80,11 @@ export default function routerDecorator($transitions, $rootScope, $cookies, $win
   async function checkSubscriptionExpiry() {
     currentPrincipal = await Principal.identity();
 
+    // Ignore subscription expiry for global users.
+    if(currentPrincipal.isGlobal) {
+      return;
+    }
+
     // Only get the subscription data when necessary.
     if(!subscription || subscription.customer_id !== currentPrincipal.FireDepartment.customer_id) {
       await refreshSubscription();


### PR DESCRIPTION
Global users should no longer see the subscription expiry modals, and should now have full access to the app.