### PR TITLE
initial multi tenancy to allow global instance

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -58,6 +58,7 @@ import departmentAdmin from './department-admin';
 import twitter from './twitter';
 import report from './report';
 import incident from './incident';
+import dashboard from './dashboard';
 
 import marketplace from './marketplace';
 
@@ -137,6 +138,7 @@ angular.module('statEngineApp', [
   statEngine,
   user,
   incident,
+  dashboard,
   incidentComponents,
   chartComponents,
   orderObjectBy,

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -1459,6 +1459,7 @@ span+.logged-name {
 @import 'main/main';
 @import 'spade/spade';
 @import 'marketplace/marketplace';
+@import 'dashboard/dashboard';
 @import 'statEngine/statEngine';
 @import '../components/footer/footer';
 @import '../components/modal/modal';

--- a/client/app/dashboard/dashboard-tenancy/dashboard-tenancy.controller.js
+++ b/client/app/dashboard/dashboard-tenancy/dashboard-tenancy.controller.js
@@ -1,0 +1,28 @@
+'use strict';
+
+export default class DashboardTenancyController {
+  /*@ngInject*/
+  constructor(currentPrincipal, $window) {
+    this.$window = $window;
+
+    this.tenants = [{
+      slug: currentPrincipal.FireDepartment.firecares_id,
+      name: 'My Department',
+      short_description: currentPrincipal.FireDepartment.name,
+      image: currentPrincipal.FireDepartment.logo_link,
+    }];
+
+    if (currentPrincipal.isGlobal) {
+      this.tenants.push({
+        slug: 'global',
+        name: 'Global',
+        short_description: 'All Departments',
+        image: '/assets/images/nfors-branding-symbol.png',
+      });
+    }
+  }
+
+  select(tenant) {
+    this.$window.location.href = '/dashboard?tenancy=' + tenant.slug;
+  }
+}

--- a/client/app/dashboard/dashboard-tenancy/dashboard-tenancy.html
+++ b/client/app/dashboard/dashboard-tenancy/dashboard-tenancy.html
@@ -11,7 +11,7 @@
         </div>
       </section>
       <section class="container-fluid p-3 p-md-5 mx-wd-1350">
-        <section class="row">
+        <section class="row justify-content-center">
           <div class="tenants-content col-md-8">
             <section class="tenants">
               <div class="row align-items-center">

--- a/client/app/dashboard/dashboard-tenancy/dashboard-tenancy.html
+++ b/client/app/dashboard/dashboard-tenancy/dashboard-tenancy.html
@@ -1,0 +1,34 @@
+<div class="br-pagebody p-0 m-0">
+    <div class="dashboard-tenancy">
+      <section>
+        <div class="px-4 py-5">
+          <div class="row justify-content-center">
+            <div class="col-lg-12 masthead-content">
+              <h1 class="subheader">Available Tenants</h1>
+              <p>Please select your tenancy</p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="container-fluid p-3 p-md-5 mx-wd-1350">
+        <section class="row">
+          <div class="tenants-content col-md-8">
+            <section class="tenants">
+              <div class="row align-items-center">
+                <div ng-repeat="tenant in vm.tenants | filter:query as filtered" class="col">
+                  <a ng-click="vm.select(tenant)" href="#" class="card hvr-float">
+                    <img ng-src="{{tenant.image}}" alt="">
+                    <h5 class="heavyheader text-truncate">{{tenant.name}}</h5>
+                    <p>{{tenant.short_description}}</p>
+                  </a>
+                </div>
+                <div ng-if="filtered.length == 0" class="col">
+                  <p class="text-danger">No tenants available </p>
+                </div>
+              </div>
+            </section>
+          </div>
+        </section>
+      </section>
+    </div>
+  </div>

--- a/client/app/dashboard/dashboard-tenancy/dashboard-tenancy.scss
+++ b/client/app/dashboard/dashboard-tenancy/dashboard-tenancy.scss
@@ -1,0 +1,112 @@
+.dashboard-tenancy {
+  header.naked {
+    margin-bottom: 0;
+  }
+  .masthead {
+    background-position: calc(50% - 550px) 3px,calc(50% + 550px) 3px;
+    background-repeat: no-repeat,no-repeat;
+    min-height: 335px;
+  }
+  .masthead-content {
+    max-width: 650px;
+    padding-top: 4rem;
+    text-align: center;
+    h1 {
+      font-weight: 300;
+      font-size: 45px;
+    }
+    > p {
+      color: $color-pale-sky;
+      font-size: 16px;
+      margin: 1.5rem 0 2rem;
+    }
+  }
+  .tenancy-search {
+  	position: relative;
+    display: flex;
+    .search-input {
+      border-radius: 99rem;
+      box-sizing: border-box;
+      padding: 1.5rem;
+    }
+    .btn {
+      position: relative;
+      right: 1.2rem;
+      top: 0;
+      z-index: 5;
+    }
+  }
+  .categories-sidenav {
+    ul.nav {
+      margin-left: -8px;
+    }
+    .nav li {
+      width: 100%;
+       a {
+        &:hover, &:active, &:focus {
+          background-color: lighten($color-pale-sky,50%);
+          color: darken($color-cerulean,5%);
+        }
+      }
+      &.active
+      a {
+        background-color: lighten($color-pale-sky,50%);
+        color: darken($color-cerulean,5%);
+      }
+    }
+  }
+  .tenants-content {
+    a.card {
+      color: inherit;
+      padding: 1rem 1rem 1rem 7rem;
+      &:hover, &:active, &:focus {
+        text-decoration: none;
+      }
+      &:hover {
+        transform: translateY(-5px);
+      }
+      img {
+        position: absolute;
+        left: 1rem;
+        top: .8rem;
+        max-height: 4.5rem;
+      }
+      h5 {
+        font-size: 15px;
+        line-height: 1.25;
+        margin-bottom: 0.3rem;
+      }
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        margin-bottom: 0;
+
+        // Line clamp code (keep it to 3 lines only)
+  			-webkit-box-orient: vertical;
+  			display: -webkit-box;
+  			-webkit-line-clamp: 3;
+  			overflow: hidden;
+      }
+    }
+    .tenants {
+      .col {
+        min-width: 50%;
+        max-width: 50%;
+        margin-bottom: 1.5rem;
+        @include media-breakpoint-down(lg) {
+          min-width: 100%;
+          width: 100%;
+       }
+      }
+      a.card {
+        width: 100%;
+        height: 100px;
+
+        @include media-breakpoint-down(lg) {
+          max-width: 100%;
+         width: 100%;
+        }
+      }
+    }
+  }
+}

--- a/client/app/dashboard/dashboard-tenancy/index.js
+++ b/client/app/dashboard/dashboard-tenancy/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+import angular from 'angular';
+import DashboardTenancyController from './dashboard-tenancy.controller';
+
+export default angular.module('stateEngineApp.dashboard.tenancy', [])
+  .controller('DashboardTenancyController', DashboardTenancyController)
+  .name;

--- a/client/app/dashboard/dashboard.routes.js
+++ b/client/app/dashboard/dashboard.routes.js
@@ -1,0 +1,33 @@
+'use strict';
+
+export default function routes($stateProvider) {
+  'ngInject';
+
+  $stateProvider
+    .state('site.dashboard', {
+      abstract: true,
+    })
+    .state('site.dashboard.home', {
+      url: '/dashboards',
+      views: {
+        'content@': {
+          template: require('./dashboard-tenancy/dashboard-tenancy.html'),
+          controller: 'DashboardTenancyController',
+          controllerAs: 'vm',
+        }
+      },
+      data: {
+        roles: ['user']
+      },
+      resolve: {
+        currentPrincipal(Principal) {
+          return Principal.identity(true);
+        },
+        router($window, currentPrincipal) {
+          // As of now, only global users have multiple tenancies
+          // So if not global, just send straight to kibana
+          if (!currentPrincipal.isGlobal) $window.location.href = '/dashboard';
+        }
+      }
+    })
+}

--- a/client/app/dashboard/dashboard.scss
+++ b/client/app/dashboard/dashboard.scss
@@ -1,0 +1,1 @@
+@import './dashboard-tenancy/dashboard-tenancy';

--- a/client/app/dashboard/index.js
+++ b/client/app/dashboard/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+import angular from 'angular';
+import uiRouter from '@uirouter/angularjs';
+
+import routing from './dashboard.routes';
+
+// modules
+import tenancy from './dashboard-tenancy';
+
+export default angular.module('statEngineApp.dashboard', [uiRouter, tenancy])
+  .config(routing)
+  .name;

--- a/client/app/user/user-home/user-home.controller.js
+++ b/client/app/user/user-home/user-home.controller.js
@@ -128,14 +128,6 @@ export default class UserHomeController {
         });
     };
 
-    this.dashboard = function() {
-      this.AmplitudeService.track(this.AnalyticEventNames.APP_ACCESS, {
-        app: 'Dashboard',
-        location: 'user-home'
-      });
-      this.$window.location.href = '/dashboard';
-    };
-
     this.goto = function(state, appName) {
       this.userDropDownActive = false;
 

--- a/client/app/user/user-home/user-home.html
+++ b/client/app/user/user-home/user-home.html
@@ -50,7 +50,7 @@
           </p>
         </div>
         <div class="col-lg actions mg-t-5" ng-if="vm.appAccess">
-          <a href="" ng-click="vm.dashboard()">
+          <a href="" ng-click="vm.goto('site.dashboard.home','Dashboard')">
             <img src="/assets/images/actions-dashboard.svg"/>
             <span>Dashboard</span>
           </a>

--- a/client/components/auth/principal.service.js
+++ b/client/components/auth/principal.service.js
@@ -69,20 +69,16 @@ export default function PrincipalService($http, $q, $cookies, $window, User) {
     },
 
     logout() {
-      return $http.get('/auth/local/logout')
-        .finally(() => {
-          this.authenticate({});
-          const cookies = $cookies.getAll();
-          angular.forEach(cookies, (v, k) => {
-            $cookies.remove(k);
-          });
-          amplitude.getInstance().setUserId(null); // not string 'null'
-          amplitude.getInstance().regenerateDeviceId();
-          _amplitudeIdentify = false;
+      this.authenticate({});
+      const cookies = $cookies.getAll();
+      angular.forEach(cookies, (v, k) => {
+        $cookies.remove(k);
+      });
+      amplitude.getInstance().setUserId(null); // not string 'null'
+      amplitude.getInstance().regenerateDeviceId();
+      _amplitudeIdentify = false;
 
-          // invalidate server session in case kibana doesn't callback
-          return $http.get('/auth/local/logout/_callback');
-        });
+      return $http.get('/auth/local/logout');
     },
 
     signup(user) {

--- a/client/components/sidebar/sidebar.component.js
+++ b/client/components/sidebar/sidebar.component.js
@@ -38,7 +38,7 @@ export class SidebarComponent {
       app: 'Dashboard',
       location: 'sidebar',
     });
-    this.$window.location.href = '/dashboard';
+    this.$state.go('site.dashboard.home');
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/server/auth/auth.service.js
+++ b/server/auth/auth.service.js
@@ -126,6 +126,20 @@ export function hasFireDepartment(req, res, next) {
   }
 }
 
+/**
+ * Sets kibana tenancy
+ */
+export function tenancy(req, res, next) {
+  req.tenancy = req.fireDepartment.firecares_id;
+
+  // Only global users can set a tenancy for now
+  if(req.user.isGlobal && req.query.tenancy) {
+    req.tenancy = req.query.tenancy;
+  }
+
+  next();
+}
+
 /*
  * Ensures user is assigned to fire department of request path
  */

--- a/server/auth/local/index.js
+++ b/server/auth/local/index.js
@@ -40,16 +40,10 @@ router.post('/', bodyParser.json(), (req, res, next) => {
   })(req, res, next);
 });
 
-// Callback logout route
-// Kibana should call this on logout or from Angular on failure
-router.get('/logout/_callback', (req, res) => {
-  req.logout();
-  res.redirect('/');
-});
-
 // Logsout of Kibana
 router.get('/logout', (req, res) => {
-  res.redirect(path.join(config.kibana.appPath, '/logout'));
+  req.logout();
+  res.redirect('/');
 });
 
 // Route to determine if user is logged in

--- a/server/kibana/index.js
+++ b/server/kibana/index.js
@@ -17,6 +17,7 @@ router.use(
   auth.isAuthenticated,
   auth.hasRole('kibana_ro_strict'),
   auth.hasFireDepartment,
+  auth.tenancy,
   proxy(settings)
 );
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -30,7 +30,7 @@ export default function(app) {
 
   // Kibana
   app.route('/dashboard')
-    .get((req, res) => res.redirect(path.join(config.kibana.appPath, '/')));
+    .get((req, res) => res.redirect(req.originalUrl.replace('/dashboard', config.kibana.appPath)));
   app.use(config.kibana.appPath, require('./kibana'));
 
   app.use('/subscriptionPortal', require('./subscription'));


### PR DESCRIPTION
In anticipation of multi-tenancy, we need the ability to select a different kibana index (for dashboards, visualizations, etc).  This PR adds a new view to select the tenancy.  

Eventually, users will be able to create new tenants and assign permission/roles to each tenant.  However, I'll add that functionality in another request.  

But to start using the selector, I created a "hard-coded" tenancy for global users.  Global users, will now be able to select their "home" department or a global view.  

All other users will just pass through to kibana (since they just have their default tenancy)
