### PR TITLE
Email alert style updates.

### DIFF
--- a/server/api/email/email.controller.js
+++ b/server/api/email/email.controller.js
@@ -114,6 +114,21 @@ const agencyIncidentTypeMetricConfigs = [
   ['incidentCount'],
 ];
 
+const alertColors = {
+  success: {
+    row: '#dff0d8',
+    rowBorder: '#83d062',
+  },
+  warning: {
+    row: '#fcf8e3',
+    rowBorder: '#c7ba75',
+  },
+  danger: {
+    row: '#f2dede',
+    rowBorder: '#bb7474',
+  },
+};
+
 function _formatAlerts(ruleAnalysis, reportOptions) {
   let mergeVar = {
     name: 'alerts',
@@ -122,8 +137,14 @@ function _formatAlerts(ruleAnalysis, reportOptions) {
 
   _.forEach(ruleAnalysis, ruleViolations => {
     ruleViolations.forEach(violation => {
-      if(violation.level === 'DANGER') violation.rowColor = '#f2dede';
-      else if(violation.level === 'WARNING') violation.rowColor = '#fcf8e3';
+      if(violation.level === 'DANGER') {
+        violation.rowColor = alertColors.danger.row;
+        violation.rowBorderColor = alertColors.danger.rowBorder;
+      }
+      else if(violation.level === 'WARNING') {
+        violation.rowColor = alertColors.warning.row;
+        violation.rowBorderColor = alertColors.warning.rowBorder;
+      }
 
       let showAlert = _.get(reportOptions, `sections.showAlertSummary[${violation.rule}]`);
       if(_.isUndefined(showAlert) || showAlert) mergeVar.content.push(violation);
@@ -132,11 +153,17 @@ function _formatAlerts(ruleAnalysis, reportOptions) {
 
   if(mergeVar.content.length === 0) {
     mergeVar.content.push({
-      rowColor: '#dff0d8',
+      rowColor: alertColors.success.row,
+      rowBorderColor: alertColors.success.rowBorder,
       description: 'No alerts',
       details: 'Keep up the good work!'
     });
   }
+
+  // Add a space after any comma without one after it.
+  mergeVar.content.forEach(alert => {
+    alert.details = alert.details.replace(/(,(?=\S)|:)/g, ', ')
+  })
 
   return mergeVar;
 }


### PR DESCRIPTION
This should pass alert border colors to the daily email template along with the background colors. The current `timerange` template should be unaltered with this change in place. The change will only be visible once we copy over the code from the `timerange-test` template into `timerange`.

To test this change in action with the new template, you just need to change the template identifier at line 331 of `email.controller.js` to `timerange-test` and trigger a daily/weekly/monthly email from the `/departmentAdmin/email` page. The new template formatting should work across all screen widths.

Once this PR is approved and merged into master we can copy the `timerange-test` code into `timerange` to make the template updates live.