### PR TITLE
Async middleware wrapper function.

### DIFF
--- a/server/api/user/index.js
+++ b/server/api/user/index.js
@@ -3,13 +3,14 @@
 import { Router } from 'express';
 import bodyParser from 'body-parser';
 
+import { asyncMiddleware } from '../../util/async-middleware';
 import * as controller from './user.controller';
 import * as auth from '../../auth/auth.service';
 
 var router = new Router();
 
 // unprotected routes
-router.post('/', bodyParser.json(), controller.create);
+router.post('/', bodyParser.json(), asyncMiddleware(controller.create));
 router.put('/requestUsername', bodyParser.json(), controller.requestUsername);
 router.put('/resetPassword', bodyParser.json(), controller.resetPassword);
 router.put('/updatePassword', bodyParser.json(), controller.updatePassword);
@@ -18,13 +19,13 @@ router.put('/updatePassword', bodyParser.json(), controller.updatePassword);
 router.get('/me', auth.isApiAuthenticated, controller.me);
 router.put('/:id', auth.isApiAuthenticated, bodyParser.json(), controller.hasEditPermisssion, controller.edit);
 router.put('/:id/password', auth.isApiAuthenticated, bodyParser.json(), controller.hasEditPermisssion, controller.changePassword);
-router.put('/:id/requestAccess', auth.isApiAuthenticated, bodyParser.json(), controller.hasEditPermisssion, controller.requestAccess);
+router.put('/:id/requestAccess', auth.isApiAuthenticated, bodyParser.json(), controller.hasEditPermisssion, asyncMiddleware(controller.requestAccess));
 router.param('id', controller.loadUser);
 
 // department admin routes
 router.get('/', auth.isApiAuthenticated, auth.hasRole('department_admin'), controller.index);
 router.get('/:id', auth.isApiAuthenticated, auth.isApiAuthenticated, auth.hasRole('department_admin'), controller.get);
-router.put('/:id/revokeAccess', bodyParser.json(), auth.isApiAuthenticated, auth.hasRole('department_admin'), controller.hasEditPermisssion, controller.revokeAccess);
-router.put('/:id/approveAccess', bodyParser.json(), auth.isApiAuthenticated, auth.hasRole('department_admin'), controller.hasEditPermisssion, controller.approveAccess);
+router.put('/:id/revokeAccess', bodyParser.json(), auth.isApiAuthenticated, auth.hasRole('department_admin'), controller.hasEditPermisssion, asyncMiddleware(controller.revokeAccess));
+router.put('/:id/approveAccess', bodyParser.json(), auth.isApiAuthenticated, auth.hasRole('department_admin'), controller.hasEditPermisssion, asyncMiddleware(controller.approveAccess));
 
 module.exports = router;

--- a/server/api/user/user.controller.js
+++ b/server/api/user/user.controller.js
@@ -266,28 +266,24 @@ export async function create(req, res) {
   }
   user.setDataValue('api_key', uuidv4());
 
-  try {
-    await user.save();
-    addToMailingList(user);
+  await user.save();
+  addToMailingList(user);
 
-    if(!req.body.requested_fire_department_id && !req.body.fire_department__id) {
-      sendWelcomeEmail(user);
-    }
-
-    // Send access request to department admin if a department was set.
-    if(req.body.requested_fire_department_id) {
-      const department = await FireDepartment.find({
-        where: {
-          _id: req.body.requested_fire_department_id,
-        }
-      });
-      sendRequestDepartmentAccessEmail(user, department);
-    }
-
-    res.status(204).send({ user });
-  } catch (err) {
-    handleError(res);
+  if(!req.body.requested_fire_department_id && !req.body.fire_department__id) {
+    sendWelcomeEmail(user);
   }
+
+  // Send access request to department admin if a department was set.
+  if(req.body.requested_fire_department_id) {
+    const department = await FireDepartment.find({
+      where: {
+        _id: req.body.requested_fire_department_id,
+      }
+    });
+    sendRequestDepartmentAccessEmail(user, department);
+  }
+
+  res.status(204).send({ user });
 }
 
 /**
@@ -325,18 +321,14 @@ export async function requestAccess(req, res) {
 
   user.requested_fire_department_id = req.body.requested_fire_department_id;
 
-  try {
-    await user.save();
-    const department = await FireDepartment.find({
-      where: {
-        _id: user.requested_fire_department_id,
-      },
-    });
-    sendRequestDepartmentAccessEmail(user, department);
-    res.status(204).send({ user });
-  } catch (err) {
-    handleError(res);
-  }
+  await user.save();
+  const department = await FireDepartment.find({
+    where: {
+      _id: user.requested_fire_department_id,
+    },
+  });
+  sendRequestDepartmentAccessEmail(user, department);
+  res.status(204).send({ user });
 }
 
 /**
@@ -355,18 +347,14 @@ export async function revokeAccess(req, res) {
   _.pull(roles, 'kibana_ro_strict');
   user.role = roles.join(',');
 
-  try {
-    await user.save();
-    const department = await FireDepartment.find({
-      where: {
-        _id: departmentId,
-      },
-    });
-    sendAccessRevokedEmail(user, department, hadAccess);
-    res.status(204).send({ user });
-  } catch (err) {
-    handleError(res)
-  }
+  await user.save();
+  const department = await FireDepartment.find({
+    where: {
+      _id: departmentId,
+    },
+  });
+  sendAccessRevokedEmail(user, department, hadAccess);
+  res.status(204).send({ user });
 }
 
 /**
@@ -383,18 +371,14 @@ export async function approveAccess(req, res) {
   if(req.query.readonly) user.role = `${user.role},kibana_ro_strict`;
   else user.role = `${user.role},kibana_admin`;
 
-  try {
-    await user.save();
-    const department = await FireDepartment.find({
-      where: {
-        _id: user.fire_department__id,
-      },
-    });
-    sendAccessApprovedEmail(user, department, req.query.readonly);
-    res.status(204).send({ user });
-  } catch (err) {
-    handleError(res)
-  }
+  await user.save();
+  const department = await FireDepartment.find({
+    where: {
+      _id: user.fire_department__id,
+    },
+  });
+  sendAccessApprovedEmail(user, department, req.query.readonly);
+  res.status(204).send({ user });
 }
 
 /**

--- a/server/util/async-middleware.js
+++ b/server/util/async-middleware.js
@@ -1,0 +1,15 @@
+'use strict';
+
+export function asyncMiddleware(middleware) {
+  // Wrap the middleware with a try/catch block. This will deal with exceptions thrown in middleware that
+  // use async/await. Without this, the server won't send an error to the client if one occurs within
+  // async middleware, causing the client to hang if an uncaught exception occurs on the server.
+  return async (req, res, next) => {
+    try {
+      await middleware(req, res, next)
+    } catch (err) {
+      console.error(err);
+      res.status(500).send(err);
+    }
+  }
+}


### PR DESCRIPTION
There was a potential issue where uncaught exceptions within async middleware wouldn't be propagated back to the client, causing the client to hang on an unhandled server error. The error would get logged correctly on the server, but there would be no surrounding try/catch block to send the error back to the client. So this wrapper function serves as a cleaner way of wrapping the entire body of any async middleware with try/catch, sending a 500 status along with the error data to the client if any exceptions are uncaught.

As far as I can tell, this is the cleanest way to safely integrate async/await into node middleware. There doesn't seem to be any built-in system to do this. All of the articles I looked at online regarding this issue are content with manually wrapping the entire body of every async middleware with try/catch. This solution seems much nicer to me though.

I think the usages of `handleError()` in the user.controller async handlers were incorrect as well, since that function was apparently built to be passed into a promise's `catch()` call. They shouldn't be necessary anymore with this change anyways, since they were just serving as a catch-all (which `asyncMiddleware()` will do for us now). So I went ahead and removed them along with the try/catch blocks setup for them.