### PR TITLE
Fix regex issue in timerange email notifications.

### DIFF
--- a/server/api/email/email.controller.js
+++ b/server/api/email/email.controller.js
@@ -162,7 +162,7 @@ function _formatAlerts(ruleAnalysis, reportOptions) {
 
   // Add a space after any comma without one after it.
   mergeVar.content.forEach(alert => {
-    alert.details = alert.details.replace(/(,(?=\S)|:)/g, ', ')
+    alert.details = alert.details.replace(/(,(?=\S))/g, ', ')
   })
 
   return mergeVar;


### PR DESCRIPTION
There was an extra `|:` in the regex that shouldn't have been there, which was replacing colons with `, `. I double checked the regex and it should be good now.