### PR TITLE
Fix mobile body size on orientation change.

### DIFF
--- a/client/app/app.config.js
+++ b/client/app/app.config.js
@@ -35,6 +35,23 @@ export function routeConfig($urlRouterProvider, $locationProvider, $stateProvide
   // Just manually set the body height to match the window height, which will account for the extra chrome.
   fitBodyToWindow();
   angular.element(window).on('resize', fitBodyToWindow);
+  angular.element(window).on('orientationchange', async () => {
+    // Mobile devices will change their innerHeight at an undetermined time after the orientation change.
+    // So wait up to 120 frames for a change to the window innerHeight, and then refit the body to the window.
+    await new Promise(resolve => {
+      const checkInnerHeightChanged = (framesWaited, prevHeight) => {
+        if(window.innerHeight !== prevHeight || framesWaited >= 120) {
+          resolve()
+        } else {
+          window.requestAnimationFrame(() => checkInnerHeightChanged(framesWaited + 1, prevHeight));
+        }
+      };
+      checkInnerHeightChanged(0, window.innerHeight);
+    });
+
+    fitBodyToWindow();
+  });
+
   function fitBodyToWindow() {
     angular.element('body').css({
       height: `${window.innerHeight}px`,


### PR DESCRIPTION
Apparently the window's inner height doesn't change perfectly in sync with the orientationchange event. So what was happening was the orientation would change and fire a resize event, but when the body was resized to fit the window it would be using the previous orientation's height due to the delay. I grabbed a solution from stackoverflow to detect the moment the window's inner height changes and refit the body at that point. It's a little bit funky, but it works well. Here's the thread on stackoverflow for reference...

https://stackoverflow.com/questions/12452349/mobile-viewport-height-after-orientation-change