### PR TITLE
Fix high login page header.

### DIFF
--- a/client/app/account/login/login.html
+++ b/client/app/account/login/login.html
@@ -4,7 +4,7 @@
       <button class="btn btn-outline btn-sm btn-oblong hvr-backward w80" ui-sref="site.main.main"><i class="fa fa-arrow-left"></i> Back</button>
     </div>
   </div>
-  <div class="row justify-content-center animated fadeIn">
+  <div class="row my-5 justify-content-center animated fadeIn">
     <div class="col-md-auto align-self-center">
       <h1 class="text-center">Sign In</h1>
 

--- a/client/app/account/login/login.scss
+++ b/client/app/account/login/login.scss
@@ -5,8 +5,8 @@
   width: 100vw;
   height: 100vh;
   overflow: auto;
-  > div:nth-child(2){
-    height: 85%;
+  h1 {
+    margin-top: 0;
   }
   button.login {
     min-width: 138px;


### PR DESCRIPTION
This only occurred when testing on an actual mobile device (iPhone 6s for me). The header was also blocking tap events on the "Back" button, so that should be fixed as well now.

## Before
![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563336661316662323030623636353463316161393734322f38626165366466302d343633342d346365392d393065662d356632303738333266653431](https://user-images.githubusercontent.com/3220897/58170842-717d3a80-7c49-11e9-8c2a-1694e30afd8e.png)

## After
![IMG_1350](https://user-images.githubusercontent.com/3220897/58170850-75a95800-7c49-11e9-8bf9-328204e4805d.png)
