### PR TITLE
Add print support for Incident Detail page.

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -79,6 +79,7 @@ import shift from '../components/shift/shift.component';
 import onEnterPressed from '../components/on-enter-pressed/onEnterPressed.directive';
 import loadingSpinner from '../components/loading-spinner/loading-spinner.component';
 import loadingOverlay from '../components/loading-overlay/loading-overlay.component';
+import print from '../components/print/print.service';
 
 import statsTable from '../components/tables/stats-table.component';
 import safety from '../components/safety/safety.component';
@@ -171,6 +172,7 @@ angular.module('statEngineApp', [
   loadingSpinner,
   loadingOverlay,
   toggleSwitch,
+  print,
 ])
   .config(routeConfig)
   .config((appConfig, amplitudeConfig) => {

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -87,11 +87,21 @@ body {
   flex-direction: column;
   height: 100vh;
   width: 100vw;
+
+  @media print {
+    display: block;
+  }
 }
 
 .root-view {
   flex: 1;
   display: flex;
+  max-height: 100%;
+
+  @media print {
+    display: block;
+    max-height: initial;
+  }
 }
 
 .sidebar-view {
@@ -105,6 +115,16 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
+
+  @media print {
+    display: block;
+  }
+}
+
+.appbar-view {
+  @media print {
+    display: none;
+  }
 }
 
 .content-view {
@@ -112,12 +132,23 @@ body {
   @extend .ios-scroll-fix;
   flex: 1;
   overflow: auto;
+
+  @media print {
+    display: block;
+    overflow: visible;
+  }
 }
 
 .show-mobile-nav,
 .show-sidebar {
   .content-view {
     @extend .no-scroll;
+  }
+}
+
+#Smallchat {
+  @media print {
+    display: none;
   }
 }
 
@@ -1513,6 +1544,49 @@ span+.logged-name {
 
 .ios-scroll-fix {
   -webkit-overflow-scrolling: touch; // Fix iOS momentum scrolling.
+}
+
+// HACK: Fix printing overlap with page headers/footers in Chrome.
+@page {
+  margin: 5rem 2rem;
+}
+
+// HACK: Safari doesn't seem to apply responsive styling in print mode, so we have to force some
+// page properties here to make things look right. The crazy media query will detect Safari browsers.
+@media not all and (min-resolution:.001dpcm) {
+  @supports (-webkit-appearance:none) {
+    @media print {
+      .sidebar-view {
+        display: none;
+      }
+
+      html, body {
+        width: 215.9mm; // Letter Paper width
+      }
+    }
+  }
+}
+
+.weather-cube {
+  // ==========
+  // TODO: Dynamically change background color based on weather summary type
+  // ==========
+
+  background: rgb(53, 144, 231);
+  background: linear-gradient(149deg, rgba(53, 144, 231, 1) 0%, rgba(54, 187, 214, 1) 100%); // background: rgb(236,115,99);
+  // background: linear-gradient(149deg, rgba(236,115,99,1) 0%, rgba(239,200,69,1) 100%);
+  // background: rgb(38,46,89);
+  // background: linear-gradient(149deg, rgba(38,46,89,1) 0%, rgba(76,78,153,1) 100%);
+  // background: rgb(172,99,93);
+  // background: linear-gradient(149deg, rgba(172,99,93,1) 0%, rgba(230,186,141,1) 100%);
+  border-radius: 3px;
+  color: white;
+  text-align: center;
+  padding: 2rem 2rem .75rem;
+
+  h3 {
+    margin: 1rem 0 0 0;
+  }
 }
 
 /////////////////////////////////

--- a/client/app/incident/incident-analysis/incident-analysis.controller.js
+++ b/client/app/incident/incident-analysis/incident-analysis.controller.js
@@ -248,5 +248,10 @@ export default class IncidentAnalysisController {
     this.uiGridApi.core.handleWindowResize();
 
     this.showFullComments(false);
+
+    this.AmplitudeService.track(this.AnalyticEventNames.APP_ACTION, {
+      app: 'Incident Analysis',
+      action: 'print',
+    });
   };
 }

--- a/client/app/incident/incident-analysis/incident-analysis.controller.js
+++ b/client/app/incident/incident-analysis/incident-analysis.controller.js
@@ -6,6 +6,7 @@ import humanizeDuration from 'humanize-duration';
 
 let _;
 let tippy;
+let PlotlyBasic;
 
 const shortEnglishHumanizer = humanizeDuration.humanizer({
   language: 'shortEn',
@@ -25,17 +26,20 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
 
 export default class IncidentAnalysisController {
   /*@ngInject*/
-  constructor(AmplitudeService, AnalyticEventNames, currentPrincipal, incidentData) {
+  constructor($scope, AmplitudeService, AnalyticEventNames, currentPrincipal, incidentData, Print) {
+    this.$scope = $scope;
     this.AmplitudeService = AmplitudeService;
     this.AnalyticEventNames = AnalyticEventNames;
     this.currentPrincipal = currentPrincipal;
     this.incidentData = incidentData;
+    this.Print = Print;
   }
 
   async loadModules() {
     _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
     tippy = await import(/* webpackChunkName: "tippy" */ 'tippy.js');
     tippy = tippy.default;
+    PlotlyBasic = await import(/* webpackChunkName: "plotly-basic" */ 'plotly.js/dist/plotly-basic.js');
   }
 
   async $onInit() {
@@ -55,7 +59,7 @@ export default class IncidentAnalysisController {
     let comments = _.get(this.incident, 'description.comments');
     if(comments) {
       let limit = 500;
-      this.showFullComments = false;
+      this.isShowingFullComments = false;
       this.commentsTruncated = comments.substring(0, limit);
       this.isCommentsTruncated = comments.length > limit;
     }
@@ -113,12 +117,23 @@ export default class IncidentAnalysisController {
       }, {
         field: 'description.type',
         displayName: 'Type',
-      }]
+      }],
+      onRegisterApi: (uiGridApi) => {
+        this.uiGridApi = uiGridApi;
+      },
     };
     this.formatSearchResults(this.concurrentIncidents);
 
     this.initialized = true;
     this.initTippy();
+
+    this.Print.addBeforePrintListener(this.beforePrint);
+    this.Print.addAfterPrintListener(this.afterPrint);
+
+    this.$scope.$on('$destroy', () => {
+      this.Print.removeBeforePrintListener(this.beforePrint);
+      this.Print.removeAfterPrintListener(this.afterPrint);
+    });
   }
 
   initTippy() {
@@ -190,14 +205,48 @@ export default class IncidentAnalysisController {
     $('.content-view').animate({ scrollTop: $(location).offset().top }, 1000);
   }
 
-  toggleComments() {
-    if(this.showFullComments) $('#fullComments').collapse('show');
-    else $('#fullComments').collapse('hide');
-    this.showFullComments = !this.showFullComments;
+  showFullComments(show) {
+    if(show) {
+      $('#fullComments').collapse('show');
+    } else {
+      $('#fullComments').collapse('hide');
+    }
+
+    this.isShowingFullComments = show;
   }
 
   humanizeDuration(ms) {
     if (_.isNil(ms) || _.isNaN(ms)) return 'N/A';
     return shortEnglishHumanizer(ms, { round: true });
   }
+
+  print() {
+    this.Print.print();
+  }
+
+  beforePrint = () => {
+    // HACK: Some elements won't seem to auto resize on print, so we have to hardcode their widths for now.
+    const plots = $('.js-plotly-plot');
+    for(const plot of plots) {
+      PlotlyBasic.relayout(plot, { width: 960 });
+    }
+
+    $('.concurrent-incidents-table').css({ width: '960px' });
+    this.uiGridApi.core.handleWindowResize();
+
+    this.showFullComments(true);
+  };
+
+  afterPrint = () => {
+    // Remove hardcoded plot widths.
+    const plots = $('.js-plotly-plot');
+    for(const plot of plots) {
+      PlotlyBasic.relayout(plot, { width: 0 });
+    }
+
+    $('.concurrent-incidents-table').css({ width: 'auto' });
+    this.uiGridApi.core.handleWindowResize();
+
+    this.showFullComments(false);
+  };
 }

--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -9,8 +9,11 @@
   </div><!-- br-pageheader -->
   <div class="br-pagetitle bg-white d-flex justify-content-between flex-wrap">
     <h2 class="m-0">Incident {{ vm.incident.description.incident_number }}</h2>
+    <button class="print-button btn btn-primary" ng-click="vm.print()">
+      Print
+    </button>
   </div>
-  <div class="ht-md-60 pb-3 pb-md-0 pd pd-x-15 pd-sm-x-25 bd-b d-flex align-items-center justify-content-start bg-white">
+  <div class="incident-analysis-tabs">
     <ul class="nav nav-outline active-info align-items-start flex-column flex-md-row" role="tablist">
       <li class="nav-item tx-medium pl-0"><a class="nav-link active" data-toggle="tab" href="#overview" role="tab">Overview</a></li>
       <li class="nav-item tx-medium"><a class="nav-link" data-toggle="tab" href="#" role="tab" ng-click="vm.scrollTo('#location')">Location</a></li>
@@ -27,8 +30,6 @@
 
           <!-- Overview -->
           <section class="overview" id="overview">
-            <div class="section-header">Overview</div>
-
             <!-- Overview Intro -->
             <div class="overview-intro card">
               <div class="card-body">
@@ -110,12 +111,15 @@
                 <div ng-if="!vm.incident.description.comments" class="d-flex h-100">
                   <h5 class="tx-gray-500 m-auto pd-b-20">No dispatch comments available</h5>
                 </div>
-                <p ng-if="!vm.showFullComments">{{ vm.commentsTruncated }}</p>
-                <p ng-if="vm.showFullComments">{{ vm.incident.description.comments }}</p>
-                <div class="text-center">
-                  <span ng-if="vm.isCommentsTruncated && !vm.showFullComments"><a href="#" ng-click="vm.toggleComments()">Show
-                      All</a></span>
-                  <span ng-if="vm.isCommentsTruncated && vm.showFullComments"><a href="#" ng-click="vm.toggleComments()">Hide</a></span>
+                <p ng-if="!vm.isShowingFullComments">{{ vm.commentsTruncated }}</p>
+                <p ng-if="vm.isShowingFullComments">{{ vm.incident.description.comments }}</p>
+                <div class="dispatch-comments-show-hide text-center">
+                  <span ng-if="vm.isCommentsTruncated && !vm.isShowingFullComments">
+                    <a href="#" ng-click="vm.showFullComments(true)">Show All</a>
+                  </span>
+                  <span ng-if="vm.isCommentsTruncated && vm.isShowingFullComments">
+                    <a href="#" ng-click="vm.showFullComments(false)">Hide</a>
+                  </span>
                 </div>
               </div>
             </div>
@@ -145,8 +149,6 @@
 
           <!-- Location -->
           <section class="location" id="location">
-            <div class="section-header">Location</div>
-
             <!-- Map -->
             <div class="location-map card">
               <div class="row">
@@ -302,8 +304,6 @@
 
           <!-- Situational Awareness -->
           <section class="situational-awareness" id="situationalAwareness">
-            <div class="section-header">Situational Awareness</div>
-
             <!-- Weather Conditions -->
             <div class="weather-conditions card">
               <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
@@ -349,8 +349,6 @@
 
           <!-- Response -->
           <section class="response" id="response" ng-show="!vm.incident.description.suppressed">
-            <div class="section-header">Response</div>
-
             <!-- Response Overview -->
             <div class="response-overview card">
               <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
@@ -498,7 +496,7 @@
                 <p class="card-subtitle tx-normal mg-b-15">There were <span class="badge badge-secondary tx-14">
                   {{ vm.concurrentIncidents.length }} </span> incidents also in
                   progress during this timeframe</p>
-                <div ui-grid="vm.concurrentIncidentTableOptions">
+                <div class="concurrent-incidents-table" ui-grid="vm.concurrentIncidentTableOptions">
                   <div class="watermark" ng-show="!vm.concurrentIncidentTableOptions.data.length">
                     No concurrent incidents
                   </div>

--- a/client/app/incident/incident-analysis/incident-analysis.scss
+++ b/client/app/incident/incident-analysis/incident-analysis.scss
@@ -1,19 +1,109 @@
 .incident-analysis {
+  .br-pageheader {
+    @media print {
+      display: none;
+    }
+  }
+
+  .br-pagebody {
+    margin-top: 0;
+
+    @media print {
+      margin-top: 30px;
+    }
+  }
+
+  .print-button {
+    @media print {
+      display: none;
+    }
+  }
+
+  .incident-analysis-tabs {
+    @extend .ht-md-60;
+    @extend .pb-3;
+    @extend .pb-md-0;
+    @extend .pd-x-15;
+    @extend .pd-sm-x-25;
+    @extend .bd-b;
+    display: flex;
+    justify-content: start;
+    align-items: center;
+    background: white;
+
+    @media print {
+      display: none;
+    }
+  }
+
   .incident-analysis-content {
+    @extend .container-fluid;
+
+    max-width: 1230px;
+
+    @media print {
+      display: block;
+      margin: 0;
+      padding: 0;
+
+      > .row {
+        display: block;
+
+        > *[class*="col-"] {
+          display: block;
+        }
+      }
+    }
+
     section {
       display: grid;
       grid-template-columns: 50%;
       grid-gap: 2rem;
+      padding-top: 2rem;
 
       &:not(:first-child) {
         @extend .mt-5;
       }
 
+      > :first-child::before {
+        @extend .tx-13;
+        @extend .tx-spacing-1;
+        @extend .tx-gray-500;
+        @extend .tx-uppercase;
+        @extend .tx-medium;
+        font-family: 'Montserrat', sans-serif;
+        grid-area: section-header;
+        margin-bottom: -1rem;
+        transform: translateY(-200%);
+      }
+
       @include media-breakpoint-down(md) {
         grid-template-areas: unset !important;
         grid-template-columns: auto !important;
-        > * {
+
+        > *,
+        > :first-child::before {
           grid-area: unset !important;
+        }
+      }
+
+      @media print {
+        display: block;
+        color-adjust: exact;
+        -webkit-print-color-adjust: exact;
+
+        .card {
+          margin: 2rem 0;
+          break-inside: avoid;
+          page-break-inside: avoid;
+
+          &:first-child {
+            margin: 0;
+          }
+
+          .card-option {
+            display: none;
+          }
         }
       }
 
@@ -23,6 +113,10 @@
           'overview-intro       overview-intro'
           'incident-summary     dispatch-comments'
           'performance-analysis performance-analysis';
+
+        > :first-child::before {
+          content: 'Overview';
+        }
 
         .overview-intro {
           grid-area: overview-intro;
@@ -53,10 +147,17 @@
 
         .dispatch-comments {
           grid-area: dispatch-comments;
+          page-break-before: always;
 
           p {
             font-family: monospace;
             font-size: 15px;
+          }
+
+          .dispatch-comments-show-hide {
+            @media print {
+              display: none;
+            }
           }
         }
 
@@ -122,6 +223,10 @@
           'map            map'
           'census-data    parcel-data';
 
+        > :first-child::before {
+          content: 'Location';
+        }
+
         .location-summary {
           @media (max-width: 768px) {
             > .row {
@@ -173,29 +278,12 @@
           'section-header     section-header'
           'weather-conditions traffic-conditions';
 
+        > :first-child::before {
+          content: 'Situational Awareness';
+        }
+
         .weather-conditions {
           grid-area: weather-conditions;
-
-          // ==========
-          // TODO: Dynamically change background color based on weather summary type
-          // ==========
-          .weather-cube {
-            background: rgb(53, 144, 231);
-            background: linear-gradient(149deg, rgba(53, 144, 231, 1) 0%, rgba(54, 187, 214, 1) 100%); // background: rgb(236,115,99);
-            // background: linear-gradient(149deg, rgba(236,115,99,1) 0%, rgba(239,200,69,1) 100%);
-            // background: rgb(38,46,89);
-            // background: linear-gradient(149deg, rgba(38,46,89,1) 0%, rgba(76,78,153,1) 100%);
-            // background: rgb(172,99,93);
-            // background: linear-gradient(149deg, rgba(172,99,93,1) 0%, rgba(230,186,141,1) 100%);
-            border-radius: 3px;
-            color: white;
-            text-align: center;
-            padding: 2rem 2rem .75rem;
-
-            h3 {
-              margin: 1rem 0 0 0;
-            }
-          }
 
           .weather-summary {
             @media (min-width: 992px) and (max-width: 1199px) {
@@ -245,6 +333,10 @@
           'travel-distances         travel-durations'
           'response-duration        response-duration-comparisons'
           'concurrent-incidents     concurrent-incidents';
+
+        > :first-child::before {
+          content: 'Response';
+        }
 
         .response-overview {
           grid-area: response-overview;
@@ -355,17 +447,6 @@
         .concurrent-incidents {
           grid-area: concurrent-incidents;
         }
-      }
-
-      .section-header {
-        @extend .tx-13;
-        @extend .tx-spacing-1;
-        @extend .tx-gray-500;
-        @extend .tx-uppercase;
-        @extend .tx-medium;
-        font-family: 'Montserrat', sans-serif;
-        grid-area: section-header;
-        margin-bottom: -1rem;
       }
     }
 

--- a/client/app/reporting/reporting-unit/reporting-unit.controller.js
+++ b/client/app/reporting/reporting-unit/reporting-unit.controller.js
@@ -40,8 +40,9 @@ export default class ReportingUnitController {
   incidentsTable;
 
   /*@ngInject*/
-  constructor($window, $location, $state, $stateParams, $transitions, $timeout, AmplitudeService,
+  constructor($scope, $window, $location, $state, $stateParams, $transitions, $timeout, AmplitudeService,
               AnalyticEventNames, currentPrincipal, Unit, units) {
+    this.$scope = $scope;
     this.$window = $window;
     this.$location = $location;
     this.$state = $state;
@@ -126,10 +127,10 @@ export default class ReportingUnitController {
         this.fetchUnitData();
       }
     });
-  }
 
-  $onDestroy() {
-    this.removeResizeEventListener();
+    this.$scope.$on('$destroy', () => {
+      this.removeResizeEventListener();
+    });
   }
 
   get selectedTimeFilterId() {

--- a/client/components/incident/incident-alarm-answering-graph.component.js
+++ b/client/components/incident/incident-alarm-answering-graph.component.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import angular from 'angular';
-
 let _;
 let PlotlyBasic;
 
@@ -18,18 +16,8 @@ export default class IncidentAlarmAnsweringGraphComponent {
     _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
   }
 
-  onResize() {
-    PlotlyBasic.Plots.resize(this.id);
-  }
-
-  $onDestroy() {
-    angular.element(this.$window).off('resize', this.onResize);
-  }
-
   async $onInit() {
     await this.loadModules();
-
-    angular.element(this.$window).on('resize', this.onResize);
 
     // Get alarm durations
     const data = [];
@@ -136,6 +124,9 @@ export default class IncidentAlarmAnsweringGraphComponent {
       }]
     };
 
-    PlotlyBasic.newPlot(this.id, data, layout, {displayModeBar: false});
+    PlotlyBasic.newPlot(this.id, data, layout, {
+      displayModeBar: false,
+      responsive: true,
+    });
   }
 }

--- a/client/components/incident/incident-alarm-processing-graph.component.js
+++ b/client/components/incident/incident-alarm-processing-graph.component.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import angular from 'angular';
-
 let _;
 let PlotlyBasic;
 
@@ -18,18 +16,8 @@ export default class IncidentAlarmProcessingGraphComponent {
     _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
   }
 
-  onResize() {
-    PlotlyBasic.Plots.resize(this.id);
-  }
-
-  $onDestroy() {
-    angular.element(this.$window).off('resize', this.onResize);
-  }
-
   async $onInit() {
     await this.loadModules();
-
-    angular.element(this.$window).on('resize', this.onResize);
 
     // Get alarm durations
     const data = [];
@@ -137,6 +125,9 @@ export default class IncidentAlarmProcessingGraphComponent {
       }]
     };
 
-    PlotlyBasic.newPlot(this.id, data, layout, {displayModeBar: false});
+    PlotlyBasic.newPlot(this.id, data, layout, {
+      displayModeBar: false,
+      responsive: true,
+    });
   }
 }

--- a/client/components/incident/incident-comparison-graph.component.js
+++ b/client/components/incident/incident-comparison-graph.component.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import angular from 'angular';
-
 let _;
 let PlotlyBasic;
 
@@ -16,14 +14,6 @@ export default class IncidentComparisonGraphComponent {
   async loadModules() {
     PlotlyBasic = await import(/* webpackChunkName: "plotly-basic" */ 'plotly.js/dist/plotly-basic.js');
     _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
-  }
-
-  onResize() {
-    PlotlyBasic.Plots.resize(this.id);
-  }
-
-  $onDestroy() {
-    angular.element(this.$window).off('resize', this.onResize);
   }
 
   async $onInit() {
@@ -120,7 +110,8 @@ export default class IncidentComparisonGraphComponent {
         linecolor: '#d7dee3',
       },
     }, {
-      displayModeBar: false
+      displayModeBar: false,
+      responsive: true,
     });
   }
 }

--- a/client/components/incident/incident-timeline.component.js
+++ b/client/components/incident/incident-timeline.component.js
@@ -14,10 +14,11 @@ export default class IncidentTimelineComponent {
   incident;
   timezone;
 
-  constructor($window) {
+  constructor($window, Print) {
     'ngInject';
 
     this.$window = $window;
+    this.Print = Print;
   }
 
   async loadModules() {
@@ -350,9 +351,27 @@ export default class IncidentTimelineComponent {
     this.element = angular.element(document.querySelector('#incident-timeline'));
     // eslint-disable-next-line
     this.timeline = new Timeline(this.element[0], items, groups, options);
+
+    this.Print.addBeforePrintListener(this.beforePrint);
+    this.Print.addAfterPrintListener(this.afterPrint)
   }
 
-  $onDestory() {
-    if(this.timeline) this.timeline.destroy();
+  $onDestroy() {
+    if(this.timeline) {
+      this.timeline.destroy();
+    }
+
+    this.Print.removeBeforePrintListener(this.beforePrint);
+    this.Print.removeAfterPrintListener(this.afterPrint);
   }
+
+  beforePrint = () => {
+    // HACK: Timelines won't seem to auto resize on print, so we have to hardcode the width for now.
+    this.timeline.setOptions({ width: 960 });
+  };
+
+  afterPrint = () => {
+    // Remove hardcoded timeline width.
+    this.timeline.setOptions({ width: '100%' });
+  };
 }

--- a/client/components/incident/incident-unit-response-graph.component.js
+++ b/client/components/incident/incident-unit-response-graph.component.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import angular from 'angular';
-
 let _;
 let PlotlyBasic;
 
@@ -18,18 +16,8 @@ export default class IncidentUnitResponseGraphComponent {
     _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
   }
 
-  onResize() {
-    PlotlyBasic.Plots.resize(this.id);
-  }
-
-  $onDestroy() {
-    angular.element(this.$window).off('resize', this.onResize);
-  }
-
   async $onInit() {
     await this.loadModules();
-
-    angular.element(this.$window).on('resize', this.onResize);
 
     // Get turnout and travel durations
     const unitTimelineData = [];
@@ -129,6 +117,9 @@ export default class IncidentUnitResponseGraphComponent {
       }]
     };
 
-    PlotlyBasic.newPlot(this.id, unitTimelineData, layout, {displayModeBar: false});
+    PlotlyBasic.newPlot(this.id, unitTimelineData, layout, {
+      displayModeBar: false,
+      responsive: true,
+    });
   }
 }

--- a/client/components/incident/incident-unit-travel-distance-graph.component.js
+++ b/client/components/incident/incident-unit-travel-distance-graph.component.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import angular from 'angular';
-
 let _;
 let PlotlyBasic;
 
@@ -16,14 +14,6 @@ export default class IncidentUnitTravelDistanceGraphComponent {
   async loadModules() {
     PlotlyBasic = await import(/* webpackChunkName: "plotly-basic" */ 'plotly.js/dist/plotly-basic.js');
     _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
-  }
-
-  onResize() {
-    PlotlyBasic.Plots.resize(this.id);
-  }
-
-  $onDestroy() {
-    angular.element(this.$window).off('resize', this.onResize);
   }
 
   async $onInit() {
@@ -92,7 +82,10 @@ export default class IncidentUnitTravelDistanceGraphComponent {
         },
         annotations,
       };
-      PlotlyBasic.newPlot(this.id, data, layout, {displayModeBar: false});
+      PlotlyBasic.newPlot(this.id, data, layout, {
+        displayModeBar: false,
+        responsive: true,
+      });
     }
   }
 }

--- a/client/components/incident/incident-unit-travel-duration-graph.component.js
+++ b/client/components/incident/incident-unit-travel-duration-graph.component.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import angular from 'angular';
-
 let _;
 let PlotlyBasic;
 
@@ -18,18 +16,8 @@ export default class IncidentUnitTravelDurationGraphComponent {
     _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
   }
 
-  onResize() {
-    PlotlyBasic.Plots.resize(this.id);
-  }
-
-  $onDestroy() {
-    angular.element(this.$window).off('resize', this.onResize);
-  }
-
   async $onInit() {
     await this.loadModules();
-
-    angular.element(this.$window).on('resize', this.onResize);
 
     const units = [];
 
@@ -107,6 +95,9 @@ export default class IncidentUnitTravelDurationGraphComponent {
       },
 
     };
-    PlotlyBasic.newPlot(this.id, data, layout, {displayModeBar: false});
+    PlotlyBasic.newPlot(this.id, data, layout, {
+      displayModeBar: false,
+      responsive: true,
+    });
   }
 }

--- a/client/components/incident/incident.scss
+++ b/client/components/incident/incident.scss
@@ -124,3 +124,16 @@
 .vis.timeline .item.dot {
     display: none;
 }
+
+.mapboxgl-canvas {
+  @media print {
+    width: 100% !important;
+    height: 100% !important;
+  }
+}
+
+.mapboxgl-control-container {
+  @media print {
+    display: none;
+  }
+}

--- a/client/components/print/print.service.js
+++ b/client/components/print/print.service.js
@@ -1,0 +1,85 @@
+'use strict';
+
+import angular from 'angular';
+
+export function Print($window) {
+  const beforePrintListeners = [];
+  const afterPrintListeners = [];
+
+  const beforePrint = () => {
+    beforePrintListeners.forEach(listener => listener());
+  };
+
+  const afterPrint = () => {
+    afterPrintListeners.forEach(listener => listener());
+  };
+
+  // Setup standard print hooks.
+  window.onbeforeprint = beforePrint;
+  window.onafterprint = afterPrint;
+
+  // Safari has to use matchMedia for print hooks.
+  const isSafari = (
+    navigator.vendor && navigator.vendor.indexOf('Apple') > -1 &&
+    navigator.userAgent &&
+    navigator.userAgent.indexOf('CriOS') === -1 &&
+    navigator.userAgent.indexOf('FxiOS') === -1
+  );
+
+  if(isSafari && window.matchMedia) {
+    const mediaQueryList = window.matchMedia('print');
+    mediaQueryList.addListener(mql => {
+      if (mql.matches) {
+        beforePrint();
+      } else {
+        afterPrint();
+      }
+    });
+  }
+
+  return {
+    addBeforePrintListener(listener) {
+      beforePrintListeners.push(listener);
+    },
+
+    addAfterPrintListener(listener) {
+      afterPrintListeners.push(listener);
+    },
+
+    removeBeforePrintListener(listener) {
+      const index = beforePrintListeners.indexOf(listener);
+      if(index < 0) {
+        console.warn('Could not find beforePrint listener to remove!');
+        return;
+      }
+
+      beforePrintListeners.splice(index, 1);
+    },
+
+    removeAfterPrintListener(listener) {
+      const index = afterPrintListeners.indexOf(listener);
+      if(index < 0) {
+        console.warn('Could not find afterPrint listener to remove!');
+        return;
+      }
+
+      afterPrintListeners.splice(index, 1);
+    },
+
+    print() {
+      // HACK: The window beforePrint hook seems to get hit too late when calling window.print(), so call it
+      // manually here to make sure it runs before the page is rendered. This will have the side-effect of
+      // calling beforePrint() twice, but as long as it's idempotent that should be fine.
+      beforePrint();
+
+      // We also have to wait a moment before showing the print dialog to reflect the beforePrint changes.
+      setTimeout(() => {
+        $window.print();
+      });
+    },
+  };
+}
+
+export default angular.module('directives.print', [])
+  .factory('Print', Print)
+  .name;


### PR DESCRIPTION
This should work perfectly in Chrome, and acceptably across all other major browsers. There are a couple known issues when printing from Firefox, Safari, and Edge, but they're relatively minor and extremely difficult to track down, so I think I'll just create tasks for them...

In non-Chrome browsers there's a slight issue with the graphs being a little too wide for their containers. They're still fully visible - they just look a little wonky spilling beyond the border a little on the right side. This seems to be a side-effect of manually sizing the graphs, since they won't seem to automatically resize when rendering the print view despite my best efforts. So, at the moment, I have the sizing and printed page margins hardcoded to look perfect when printing from Chrome at the expense of looking slightly imperfect on the other browsers.

There's also an issue I spotted in Firefox where the map doesn't print at all. It doesn't seem to be an issue in other browsers though, and could be very tricky to figure out, so I'm punting on it for now unless you think it's worth spending a bit of time on.