### PR TITLE
Fix incident overview top padding on small screens.

### DIFF
--- a/client/app/incident/incident-analysis/incident-analysis.scss
+++ b/client/app/incident/incident-analysis/incident-analysis.scss
@@ -81,6 +81,10 @@
         grid-template-areas: unset !important;
         grid-template-columns: auto !important;
 
+        &:first-child {
+          padding-top: 4rem;
+        }
+
         > *,
         > :first-child::before {
           grid-area: unset !important;


### PR DESCRIPTION
This bug was introduced in the mini-revamp recently.

## Before
<img width="969" alt="Screen Shot 2019-06-18 at 12 04 22 AM" src="https://user-images.githubusercontent.com/3220897/59660231-de0e2b00-915c-11e9-8817-c466be9c916a.png">

## After
<img width="969" alt="Screen Shot 2019-06-18 at 12 06 14 AM" src="https://user-images.githubusercontent.com/3220897/59660266-f54d1880-915c-11e9-9c7a-7d6b166e446b.png">

