### PR TITLE
Incident analysis page revamp

### DIFF
--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -956,6 +956,16 @@ $btn-sm-padding: 6px 12px;
   font-size: 86%;
 }
 
+// Containers
+@mixin container-fluid-max-width($max-width: 1230px) {
+  @extend .container-fluid;
+  max-width: $max-width;
+}
+
+.container-fluid-max-width {
+  @include container-fluid-max-width;
+}
+
 /////////////////////////////////
 // Sticky Footer //
 /////////////////////////////////
@@ -1444,11 +1454,24 @@ span+.logged-name {
 // Cards
 .card {
   border-color: lighten($color-cloudy-sky, 10%);
+  line-height: 1.75;
+
   .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: white;
+    border: none;
     padding: 1.25rem 0 0;
-    // border-bottom: 1px solid #cbd6df;
     margin: 0 1.25rem;
   }
+
+  .card-title {
+    margin-bottom: 0;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+  }
+
   .card-option>a {
     color: lighten($color-pale-sky, 23%);
     &:hover {
@@ -1593,6 +1616,51 @@ span+.logged-name {
 
   h3 {
     margin: 1rem 0 0 0;
+  }
+}
+
+nav.section-nav {
+  padding: 1.5rem 25px 0.5rem;
+  border-bottom: solid 1px $input-border-color;
+  background: white;
+
+  @include media-breakpoint-down(xs) {
+    padding: 1rem 15px 0;
+  }
+
+  .section-nav-links {
+    display: flex;
+    align-items: start;
+
+    @media print {
+      display: none;
+    }
+
+    @include media-breakpoint-down(sm) {
+      flex-direction: column;
+    }
+
+    a {
+      color: #697983;
+      margin: 0 1rem;
+      font-weight: 500;
+
+      &:hover {
+        color: #202e36;
+      }
+
+      &:first-child {
+        margin-left: 0;
+      }
+
+      &:last-child {
+        margin-right: 0;
+      }
+
+      @include media-breakpoint-down(sm) {
+        margin: 0.5rem 0;
+      }
+    }
   }
 }
 

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -1701,4 +1701,5 @@ nav.section-nav {
 @import '../components/reporting-unit-list/reporting-unit-list';
 @import '../components/plotly-wrapper/plotly-wrapper';
 @import '../components/toggle-switch/toggle-switch';
+@import '../components/weather/current-weather';
 // endinject //

--- a/client/app/incident/incident-analysis/incident-analysis.controller.js
+++ b/client/app/incident/incident-analysis/incident-analysis.controller.js
@@ -56,12 +56,16 @@ export default class IncidentAnalysisController {
     this.subtype = this.incident.description.subtype;
     this.firstUnitDispatched = _.get(_.find(this.incident.apparatus, u => _.get(u, 'unit_status.dispatched.order') === 1), 'unit_id');
     this.firstUnitArrived = _.get(_.find(this.incident.apparatus, u => _.get(u, 'unit_status.dispatched.order') === 1), 'unit_id');
-    let comments = _.get(this.incident, 'description.comments');
-    if(comments) {
-      let limit = 500;
-      this.isShowingFullComments = false;
-      this.commentsTruncated = comments.substring(0, limit);
-      this.isCommentsTruncated = comments.length > limit;
+    this.comments = _.get(this.incident, 'description.comments');
+    if(this.comments) {
+      const limit = 8;
+      this.comments = this.comments.split('**').slice(1);
+      this.comments.forEach((comment, i) => {
+        this.comments[i] = comment.trim();
+      });
+      this.isShowingAllComments = false;
+      this.commentsTruncated = this.comments.slice(0, limit);
+      this.isCommentsTruncated = this.comments.length > limit;
     }
 
     this.textSummaries = this.incidentData.textSummaries;
@@ -212,7 +216,7 @@ export default class IncidentAnalysisController {
       $('#fullComments').collapse('hide');
     }
 
-    this.isShowingFullComments = show;
+    this.isShowingAllComments = show;
   }
 
   humanizeDuration(ms) {

--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -116,19 +116,10 @@
               <h5 class="no-data">No dispatch comments available</h5>
             </div>
             <div ng-if="!vm.isShowingAllComments">
-              <div
-                class="dispatch-comments-comment truncated"
-                ng-repeat="comment in vm.commentsTruncated track by $index"
-                ng-attr-title="{{ comment }}"
-              >
-                {{ comment }}
-              </div>
-              <div ng-if="vm.isCommentsTruncated">...</div>
+              {{ vm.commentsTruncated }}
             </div>
             <div ng-if="vm.isShowingAllComments">
-              <div class="dispatch-comments-comment" ng-repeat="comment in vm.comments track by $index">
-                {{ comment }}
-              </div>
+              {{ vm.comments }}
             </div>
             <div class="dispatch-comments-show-hide text-center">
               <span ng-if="vm.isCommentsTruncated && !vm.isShowingAllComments">
@@ -321,14 +312,12 @@
           </div>
           <div class="card-body">
             <div ng-if="vm.incident.weather.currently">
-              <div class="row">
-                <p class="col-md-12 mb-4">On {{ vm.incident.weather.currently.time |
+                <p>
+                  On {{ vm.incident.weather.currently.time |
                   amTimezone:vm.currentPrincipal.FireDepartment.timezone | amDateFormat:'MMMM D, YYYY HH:mm' }}
-                  the following weather conditions were observed:</p>
-                <div class="col-md-12">
-                  <current-weather weather="vm.incident.weather.currently"></current-weather>
-                </div>
-              </div>
+                  the following weather conditions were observed:
+                </p>
+                <current-weather weather="vm.incident.weather.currently"></current-weather>
             </div>
             <div ng-if="!vm.incident.weather.currently" class="d-flex">
               <div class="d-flex h-100 tx-center">
@@ -337,21 +326,6 @@
                   No weather data available at this time.
                 </h5>
               </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Traffic Conditions -->
-        <div class="traffic-conditions card">
-          <div class="card-header">
-            <h6 class="card-title">Traffic Conditions</h6>
-          </div>
-          <div class="card-body">
-            <div class="d-flex h-100 tx-center">
-              <h5 class="no-data">
-                <i class="no-data-icon fa fa-bar-chart"></i><br>
-                No traffic data available
-              </h5>
             </div>
           </div>
         </div>
@@ -403,20 +377,22 @@
             <h6 class="card-title">Events Timeline</h6>
           </div>
           <div class="card-body">
+            <div class="events-timeline-legend">
+              <div class="events-timeline-legend-items">
+                <div class="alarm-answer">Alarm Answer</div>
+                <div class="alarm-processing">Alarm Processing</div>
+                <div class="turnout-time">Turnout Time</div>
+                <div class="travel-time">Travel Time</div>
+                <div class="intervention-time">Intervention Time</div>
+                <div class="transport">Transport</div>
+                <div class="post-transport">Post Transport</div>
+                <div class="cancelled">Out-of-Service/Cancelled</div>
+              </div>
+            </div>
             <incident-timeline
               incident="vm.incident"
               timezone="vm.incident.fire_department.timezone"
             ></incident-timeline>
-            <div class="events-timeline-legend">
-              <div class="alarm-answer">Alarm Answer</div>
-              <div class="alarm-processing">Alarm Processing</div>
-              <div class="turnout-time">Turnout Time</div>
-              <div class="travel-time">Travel Time</div>
-              <div class="intervention-time">Intervention Time</div>
-              <div class="transport">Transport</div>
-              <div class="post-transport">Post Transport</div>
-              <div class="cancelled">Out-of-Service/Cancelled</div>
-            </div>
           </div>
         </div>
 
@@ -425,7 +401,7 @@
           <div class="card-header">
             <h6 class="card-title">Alarm Answering Duration</h6>
             <div class="card-option">
-              <a href="" data-tippy-html='#alarmAnswerTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+              <a class="info-icon se-icon-info tippy" href="" data-tippy-html='#alarmAnswerTippy'>&nbsp;</a>
             </div>
           </div>
           <div class="card-body">
@@ -438,7 +414,7 @@
           <div class="card-header">
             <h6 class="card-title">Alarm Processing Duration</h6>
             <div class="card-option">
-              <a href="" data-tippy-html='#alarmProcessingTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+              <a class="info-icon se-icon-info tippy" href="" data-tippy-html='#alarmProcessingTippy'>&nbsp;</a>
             </div>
           </div>
           <div class="card-body">
@@ -451,7 +427,7 @@
           <div class="card-header">
             <h6 class="card-title">Travel Distances</h6>
             <div class="card-option">
-              <a href="" data-tippy-html='#travelDistanceTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+              <a class="info-icon se-icon-info tippy" href="" data-tippy-html='#travelDistanceTippy'>&nbsp;</a>
             </div>
           </div>
           <div class="card-body">
@@ -464,7 +440,7 @@
           <div class="card-header">
             <h6 class="card-title">Travel Durations</h6>
             <div class="card-option">
-              <a href="" data-tippy-html='#travelDurationTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+              <a class="info-icon se-icon-info tippy" href="" data-tippy-html='#travelDurationTippy'>&nbsp;</a>
             </div>
           </div>
           <div class="card-body">
@@ -477,7 +453,7 @@
           <div class="card-header">
             <h6 class="card-title">Response Duration</h6>
             <div class="card-option">
-              <a href="" data-tippy-html='#responseDurationTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+              <a class="info-icon se-icon-info tippy" href="" data-tippy-html='#responseDurationTippy'>&nbsp;</a>
             </div>
           </div>
           <div class="card-body">
@@ -490,7 +466,7 @@
           <div class="card-header">
             <h6 class="card-title">Response Duration Comparisons</h6>
             <div class="card-option">
-              <a href="" data-tippy-html='#responseDurationComparisonTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+              <a class="info-icon se-icon-info tippy" href="" data-tippy-html='#responseDurationComparisonTippy'>&nbsp;</a>
             </div>
           </div>
           <div class="card-body">
@@ -507,11 +483,13 @@
             <p class="card-subtitle tx-normal mg-b-15">There were <span class="badge badge-secondary tx-14">
               {{ vm.concurrentIncidents.length }} </span> incidents also in
               progress during this timeframe</p>
-            <div class="concurrent-incidents-table" ui-grid="vm.concurrentIncidentTableOptions">
-              <div class="watermark" ng-show="!vm.concurrentIncidentTableOptions.data.length">
-                No concurrent incidents
-              </div>
-            </div>
+            <incidents-table
+              incidents="vm.concurrentIncidents"
+              min-rows-to-show="vm.concurrentIncidents.length || 5"
+              ui-grid-column-defs="vm.concurrentIncidentsUiGridColumnDefs"
+              on-ui-grid-init="vm.onUiGridInit({ uiGridApi })"
+              show-controls="false"
+            ></incidents-table>
           </div>
         </div>
       </section>

--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -7,510 +7,519 @@
       <span class="breadcrumb-item active">{{ vm.incident.description.incident_number }}</span>
     </nav>
   </div><!-- br-pageheader -->
-  <div class="br-pagetitle bg-white d-flex justify-content-between flex-wrap">
-    <h2 class="m-0">Incident {{ vm.incident.description.incident_number }}</h2>
-    <button class="print-button btn btn-primary" ng-click="vm.print()">
-      Print
-    </button>
+
+  <div class="br-pagetitle bg-white">
+    <div class="d-flex justify-content-between flex-wrap">
+      <h2 class="my-0 mr-3">Incident {{ vm.incident.description.incident_number }}</h2>
+      <button class="print-button btn btn-primary" ng-click="vm.print()">
+        Print
+      </button>
+    </div>
   </div>
-  <div class="incident-analysis-tabs">
-    <ul class="nav nav-outline active-info align-items-start flex-column flex-md-row" role="tablist">
-      <li class="nav-item tx-medium pl-0"><a class="nav-link active" data-toggle="tab" href="#overview" role="tab">Overview</a></li>
-      <li class="nav-item tx-medium"><a class="nav-link" data-toggle="tab" href="#" role="tab" ng-click="vm.scrollTo('#location')">Location</a></li>
-      <li class="nav-item tx-medium"><a class="nav-link" data-toggle="tab" href="#" role="tab" ng-click="vm.scrollTo('#situationalAwareness')">Situational
-          Awareness</a></li>
-      <li class="nav-item tx-medium"><a class="nav-link" data-toggle="tab" href="#" role="tab" ng-click="vm.scrollTo('#response')">Response</a></li>
-    </ul>
-  </div>
+
+  <nav class="section-nav">
+    <div class="section-nav-links">
+      <a href="" ng-click="vm.scrollTo('#overview')">
+        Overview
+      </a>
+      <a href="" ng-click="vm.scrollTo('#location')">
+        Location
+      </a>
+      <a href="" ng-click="vm.scrollTo('#situationalAwareness')">
+        Situational Awareness
+      </a>
+      <a href="" ng-click="vm.scrollTo('#response')">
+        Response
+      </a>
+    </div>
+  </nav>
+
   <section class="br-pagebody">
     <div class="incident-analysis-content data-spy" data-spy="scroll" data-target="#navbar-example">
-      <div class="mb-5 row">
-        <!-- BEGIN: Tab Panes/Content -->
-        <div class="col-md-12">
-
-          <!-- Overview -->
-          <section class="overview" id="overview">
-            <!-- Overview Intro -->
-            <div class="overview-intro card">
-              <div class="card-body">
-                <div class="row">
-                  <div class="col-md-2 pb-4 pb-md-0">
-                    <logo department="vm.currentPrincipal.FireDepartment"></logo>
-                  </div>
-                  <div class="col-md-8 overview-intro-summary">
-                    <div ng-if="vm.incident.description.suppressed">
-                      <div class="alert alert-danger text-center mx-5 my-2" role="alert">
-                        <p>This incident has been suppressed from analysis<span ng-if="vm.incident.description.suppressionText">
-                            because {{ vm.incident.description.suppressionText }} </span>.
-                          <br>If you think this has occurred in error, please let us know.
-                      </div>
-                      <hr>
-                    </div>
-                    <div ng-if="vm.suppressedUnits">
-                      <div class="alert alert-danger text-center mx-5 my-2" role="alert">
-                        <p>Some responses have been suppressed from analysis due to these irregularities: <span ng-if="vm.incident.description.suppressionText"> </span>
-                          <ul>
-                            <li ng-repeat="unit in vm.suppressedUnits"><strong>{{unit.suppressedText}}</strong></li>
-                          </ul>
-                          If you think this has occurred in error, please let us know.
-                      </div>
-                      <hr>
-                    </div>
-                    <h6 class="heavyheader"> {{ vm.type }} <span ng-if="vm.subtype"> - {{ vm.subtype }} </span> </h6>
-                    <p>{{ vm.textSummaries.incidentSummary }}</p>
-                  </div>
+      <!-- Overview -->
+      <section class="overview" id="overview">
+        <!-- Overview Intro -->
+        <div class="overview-intro card">
+          <div class="card-body">
+            <logo department="vm.currentPrincipal.FireDepartment"></logo>
+            <div class="overview-intro-summary">
+              <div ng-if="vm.incident.description.suppressed">
+                <div class="alert alert-danger" role="alert">
+                  <p>This incident has been suppressed from analysis<span ng-if="vm.incident.description.suppressionText">
+                      because {{ vm.incident.description.suppressionText }} </span>.
+                    <br>If you think this has occurred in error, please let us know.
                 </div>
+                <hr>
               </div>
-            </div>
-
-            <!-- Incident Summary -->
-            <div class="incident-summary card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Incident Summary</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <p class="d-flex justify-content-between mg-b-5 bd-b pd-y-5">
-                  <span class="light-label mb-0">Incident Number:</span>
-                  <span>{{ vm.incident.description.incident_number }}</span>
-                </p>
-                <p class="d-flex justify-content-between mg-b-5 bd-b pd-y-5">
-                  <span class="light-label mb-0">Event Type:</span>
-                  <span>{{ vm.incident.description.type }}</span>
-                </p>
-                <p class="d-flex justify-content-between mg-b-5 bd-b pd-y-5">
-                  <span class="light-label mb-0">Event Sub-Type:</span>
-                  <span>{{ vm.incident.description.subtype }}</span>
-                </p>
-                <p class="d-flex justify-content-between mg-b-5 bd-b pd-y-5">
-                  <span class="light-label mb-0">Date:</span>
-                  <span>{{ vm.incident.description.event_opened |
-                    amTimezone:vm.currentPrincipal.FireDepartment.timezone | amDateFormat:'MMMM Do YYYY' }}</span>
-                </p>
-                <p class="d-flex justify-content-between mg-b-5 bd-b pd-y-5">
-                  <span class="light-label mb-0">Dispatch Time:</span>
-                  <span>{{ vm.incident.description.first_unit_dispatched |
-                    amTimezone:vm.currentPrincipal.FireDepartment.timezone | amDateFormat:'HH:mm' }}</span>
-                </p>
-                <p class="d-flex justify-content-between mg-b-5 bd-b pd-y-5">
-                  <span class="light-label mb-0">Location:</span>
-                  <span>{{ vm.incident.address.address_line1 }}</span>
-                </p>
-                <p class="d-flex justify-content-between mg-b-5 pd-y-5">
-                  <span class="light-label mb-0">Event Duration:</span>
-                  <span>{{ vm.humanizeDuration(vm.incident.durations.total_event.seconds*1000) }}</span>
-                </p>
-              </div>
-            </div>
-
-            <!-- Dispatch Comments -->
-            <div class="dispatch-comments card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Dispatch Comments</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <div ng-if="!vm.incident.description.comments" class="d-flex h-100">
-                  <h5 class="tx-gray-500 m-auto pd-b-20">No dispatch comments available</h5>
-                </div>
-                <p ng-if="!vm.isShowingFullComments">{{ vm.commentsTruncated }}</p>
-                <p ng-if="vm.isShowingFullComments">{{ vm.incident.description.comments }}</p>
-                <div class="dispatch-comments-show-hide text-center">
-                  <span ng-if="vm.isCommentsTruncated && !vm.isShowingFullComments">
-                    <a href="#" ng-click="vm.showFullComments(true)">Show All</a>
-                  </span>
-                  <span ng-if="vm.isCommentsTruncated && vm.isShowingFullComments">
-                    <a href="#" ng-click="vm.showFullComments(false)">Hide</a>
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            <!-- Performance Analysis -->
-            <div class="performance-analysis card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">StatEngine&trade; Performance Analysis</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <div ng-show="!vm.incident.description.suppressed" class="performance-analysis">
-                  <div class="row">
-                    <div ng-repeat="analysis in vm.analysis" class="col-lg-2" ng-init="$last && vm.initTippy()">
-                      <div class="card ruletippy h-100" ng-attr-title="{{vm.formatEvidence(analysis.evidence)}}"
-                        ng-class="{ 'nfpa-standard': analysis.category === 'NFPA'}">
-                        <span ng-class="{ 'se-icon-circle-checkmark pass': analysis.grade === 'SUCCESS',
-                                                  'se-icon-circle-exclamation caution': analysis.grade === 'WARNING',
-                                                  'se-icon-circle-x fail': analysis.grade === 'DANGER'}"></span>
-                        <h6 class="tx-13 tx-medium mg-b-20">{{analysis.description}}</h6>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <!-- Location -->
-          <section class="location" id="location">
-            <!-- Map -->
-            <div class="location-map card">
-              <div class="row">
-                <div class="col-md-8">
-                  <incident-map incidents="[vm.incident]"></incident-map>
-                </div>
-                <div class="col-md-4 pd-30 location-summary">
-                  <div class="row mr-3">
-                    <dl>
-                      <dt>Overview</dt>
-                      <dd>{{ vm.textSummaries.locationSummary }}</dd>
-                    </dl>
-                  </div>
-                  <div class="row mr-3">
-                    <dl>
-                      <dt>Address</dt>
-                      <dd>
-                        {{ vm.incident.address.address_line1 }} <br>
-                        {{ vm.incident.address.city }}, {{ vm.incident.address.state }}
-                      </dd>
-                    </dl>
-                  </div>
-                  <div class="row mr-4">
-                    <dl>
-                      <dt>Response Zone</dt>
-                      <dd>
-                        {{ vm.incident.address.response_zone }}
-                      </dd>
-                    </dl>
-                  </div>
-                  <div class="row mr-3">
-                    <dl>
-                      <dt>First Due</dt>
-                      <dd>
-                        {{ vm.incident.address.first_due }}
-                      </dd>
-                    </dl>
-                  </div>
-                  <div class="row mr-3" ng-if="vm.incident.address.battalion">
-                    <dl>
-                      <dt>Battalion</dt>
-                      <dd>
-                        {{ vm.incident.address.battalion }}
-                      </dd>
-                    </dl>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Census Data -->
-            <div class="census-data card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Census Data</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <div ng-if="!vm.incident.address.location.census" class="d-flex h-100">
-                  <div class="m-auto pd-b-20">
-                    <h5 class="tx-gray-500">No census data available.</h5>
-                    <a href="#" class="btn btn-alt-2 btn-sm" ui-sref="site.marketplace.home">Request to Add Now</a>
-                  </div>
-                </div>
-                <div ng-if="vm.incident.address.location.census">
-                  <div class="row">
-                    <div class="col-sm-6 stat d-flex">
-                      <i class="se-icon-year fa-3x"></i>
-                      <span>
-                        <h2>2010</h2>
-                        <h4>Year</h4>
-                      </span>
-                    </div>
-                    <div ng-if="vm.incident.address.population_density === 'Urban'" class="col-sm-6 stat d-flex">
-                      <i class="se-icon-buildings fa-3x"></i>
-                      <span>
-                        <h2>{{ vm.incident.address.population_density }}</h2>
-                        <h4>Density</h4>
-                      </span>
-                    </div>
-                    <div ng-if="vm.incident.address.population_density === 'Rural'" class="col-sm-6 stat d-flex">
-                      <i class="se-icon-census-tract fa-3x"></i>
-                      <span>
-                        <h2>{{ vm.incident.address.population_density }}</h2>
-                        <h4>Density</h4>
-                      </span>
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-sm-6 stat d-flex pb-5 pb-md-3">
-                      <i class="se-icon-census-tract fa-3x"></i>
-                      <span>
-                        <h2>{{ vm.incident.address.location.census.census_2010.tract }}</h2>
-                        <h4>Tract</h4>
-                      </span>
-                    </div>
-                    <div class="col-sm-6 stat d-flex pb-5 pb-md-3">
-                      <i class="se-icon-census-block fa-3x"></i>
-                      <span>
-                        <h2>{{ vm.incident.address.location.census.census_2010.block }}</h2>
-                        <h4>Block</h4>
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Parcel Data -->
-            <div class="parcel-data card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Parcel Data</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <div ng-if="vm.incident.address.location.parcel">
-                  <div class="row">
-                    <div class="col-sm-7 stat d-flex">
-                      <i class="se-icon-land-use fa-3x"></i>
-                      <span>
-                        <h2>{{ vm.incident.address.location.parcel.land_use }}</h2>
-                        <h4>Land Use</h4>
-                      </span>
-                    </div>
-                    <div class="col-sm-5 stat d-flex">
-                      <i class="se-icon-land-area fa-3x"></i>
-                      <span>
-                        <h2><span ng-if="!vm.incident.address.location.parcel.land_area"> - </span> {{
-                          vm.incident.address.location.parcel.land_area | number:0 }}</h2>
-                        <h4>Land Area (ft&sup2;)</h4>
-                      </span>
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-sm-7 stat d-flex pb-3 pb-md-0">
-                      <i class="se-icon-dwelling-value fa-3x"></i>
-                      <span>
-                        <h2> {{ vm.incident.address.location.parcel.dwelling_value | currency:"$":0 }} </h2>
-                        <h4>Dwelling Value</h4>
-                      </span>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  ng-if="!vm.incident.address.location.parcel"
-                  class="d-flex h-100 tx-center"
-                >
-                  <h5 class="tx-gray-500 m-auto pd-b-20">
-                    <i class="fa fa-bar-chart tx-80 tx-gray-300 mg-b-20"></i><br>
-                    No parcel data available
-                  </h5>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <!-- Situational Awareness -->
-          <section class="situational-awareness" id="situationalAwareness">
-            <!-- Weather Conditions -->
-            <div class="weather-conditions card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Weather Conditions</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <div ng-if="vm.incident.weather.currently">
-                  <div class="row">
-                    <p class="col-md-12 mb-4">On {{ vm.incident.weather.currently.time |
-                      amTimezone:vm.currentPrincipal.FireDepartment.timezone | amDateFormat:'MMMM D, YYYY HH:mm' }}
-                      the following weather conditions were observed:</p>
-                    <div class="col-md-12">
-                      <current-weather weather="vm.incident.weather.currently"></current-weather>
-                    </div>
-                  </div>
-                </div>
-                <div ng-if="!vm.incident.weather.currently" class="d-flex">
-                  <div class="d-flex h-100 tx-center">
-                    <h5 class="tx-gray-500 m-auto pd-b-20">
-                      <i class="fa fa-bar-chart tx-80 tx-gray-300 mg-b-20"></i><br>
-                      No weather data available at this time.
-                    </h5>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Traffic Conditions -->
-            <div class="traffic-conditions card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Traffic Conditions</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <div class="d-flex h-100 tx-center">
-                  <h5 class="tx-gray-500 m-auto pd-b-20">
-                    <i class="fa fa-bar-chart tx-80 tx-gray-300 mg-b-20"></i><br>
-                    No traffic data available
-                  </h5>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <!-- Response -->
-          <section class="response" id="response" ng-show="!vm.incident.description.suppressed">
-            <!-- Response Overview -->
-            <div class="response-overview card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Overview</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <div class="row tx-center">
-                  <div class="col-12 col-md-4 pd-y-20 pd-md-y-0 tx-left">
-                    <p class="lh-8 mg-b-0">{{ vm.textSummaries.responseSummary }}</p>
-                  </div><!-- col-4 -->
-                  <div class="col-6 col-md-2 pd-y-20 pd-md-y-0">
-                    <p class="light-label">Call answered in</p>
-                    <h4 class="tx-info tx-normal mg-b-0">{{
-                      vm.humanizeDuration(vm.incident.durations.alarm_answer.seconds*1000) }}</h4>
-                  </div><!-- col-2 -->
-                  <div class="col-6 col-md-2 pd-y-20 pd-md-y-0 bd-l bd-color-gray-lighter">
-                    <p class="light-label">First unit dispatched</p>
-                    <h4 class="tx-info tx-normal mg-b-0">{{
-                      vm.humanizeDuration(vm.incident.durations.alarm_processing.seconds*1000) }}</h4>
-                  </div><!-- col-2 -->
-                  <div class="col-6 col-md-2 pd-y-20 pd-md-y-0 bd-l bd-md-l-0 bd-color-gray-lighter">
-                    <p class="light-label">First unit on scene</p>
-                    <h4 class="tx-info tx-normal mg-b-0">{{
-                      vm.humanizeDuration(vm.incident.durations.response.minutes*1000*60) }}</h4>
-                  </div><!-- col-2 -->
-                  <div class="col-6 col-md-2 pd-y-20 pd-md-y-0 bd-l bd-color-gray-lighter">
-                    <p class="light-label">Resolved in</p>
-                    <h4 class="tx-info tx-normal mg-b-0">{{
-                      vm.humanizeDuration(vm.incident.durations.total_event.minutes*1000*60) }}</h4>
-                  </div><!-- col-2 -->
-                </div><!-- row -->
-              </div>
-            </div>
-
-            <!-- Events Timeline -->
-            <div class="events-timeline card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Events Timeline</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <div class="row">
-                  <div class="col-lg-10">
-                    <incident-timeline incident="vm.incident" timezone="vm.incident.fire_department.timezone"></incident-timeline>
-                  </div>
-                  <div class="col-lg-2 pl-2">
-                    <ul class="events-timeline-legend">
-                      <li class="alarm-answer">Alarm Answer</li>
-                      <li class="alarm-processing">Alarm Processing</li>
-                      <li class="turnout-time">Turnout Time</li>
-                      <li class="travel-time">Travel Time</li>
-                      <li class="intervention-time">Intervention Time</li>
-                      <li class="transport">Transport</li>
-                      <li class="post-transport">Post Transport</li>
-                      <li class="cancelled">Out-of-Service/Cancelled</li>
+              <div ng-if="vm.suppressedUnits">
+                <div class="alert alert-danger" role="alert">
+                  <p>Some responses have been suppressed from analysis due to these irregularities: <span ng-if="vm.incident.description.suppressionText"> </span>
+                    <ul>
+                      <li ng-repeat="unit in vm.suppressedUnits"><strong>{{unit.suppressedText}}</strong></li>
                     </ul>
-                  </div>
+                    If you think this has occurred in error, please let us know.
+                </div>
+                <hr>
+              </div>
+              <h6 class="heavyheader"> {{ vm.type }} <span ng-if="vm.subtype"> - {{ vm.subtype }} </span> </h6>
+              <p>{{ vm.textSummaries.incidentSummary }}</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Incident Summary -->
+        <div class="incident-summary card">
+          <div class="card-header">
+            <h6 class="card-title">Incident Summary</h6>
+          </div>
+          <div class="card-body">
+            <div class="incident-summary-row">
+              <span class="incident-summary-row-label">Incident Number:</span>
+              <span>{{ vm.incident.description.incident_number }}</span>
+            </div>
+            <div class="incident-summary-row">
+              <span class="incident-summary-row-label">Event Type:</span>
+              <span>{{ vm.incident.description.type }}</span>
+            </div>
+            <div class="incident-summary-row">
+              <span class="incident-summary-row-label">Event Sub-Type:</span>
+              <span>{{ vm.incident.description.subtype }}</span>
+            </div>
+            <div class="incident-summary-row">
+              <span class="incident-summary-row-label">Date:</span>
+              <span>{{ vm.incident.description.event_opened |
+                amTimezone:vm.currentPrincipal.FireDepartment.timezone | amDateFormat:'MMMM Do YYYY' }}</span>
+            </div>
+            <div class="incident-summary-row">
+              <span class="incident-summary-row-label">Dispatch Time:</span>
+              <span>{{ vm.incident.description.first_unit_dispatched |
+                amTimezone:vm.currentPrincipal.FireDepartment.timezone | amDateFormat:'HH:mm' }}</span>
+            </div>
+            <div class="incident-summary-row">
+              <span class="incident-summary-row-label">Location:</span>
+              <span>{{ vm.incident.address.address_line1 }}</span>
+            </div>
+            <div class="incident-summary-row">
+              <span class="incident-summary-row-label">Event Duration:</span>
+              <span>{{ vm.humanizeDuration(vm.incident.durations.total_event.seconds*1000) }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Dispatch Comments -->
+        <div class="dispatch-comments card">
+          <div class="card-header">
+            <h6 class="card-title">Dispatch Comments</h6>
+          </div>
+          <div class="card-body">
+            <div ng-if="!vm.incident.description.comments" class="d-flex h-100">
+              <h5 class="no-data">No dispatch comments available</h5>
+            </div>
+            <div ng-if="!vm.isShowingAllComments">
+              <div
+                class="dispatch-comments-comment truncated"
+                ng-repeat="comment in vm.commentsTruncated track by $index"
+                ng-attr-title="{{ comment }}"
+              >
+                {{ comment }}
+              </div>
+              <div ng-if="vm.isCommentsTruncated">...</div>
+            </div>
+            <div ng-if="vm.isShowingAllComments">
+              <div class="dispatch-comments-comment" ng-repeat="comment in vm.comments track by $index">
+                {{ comment }}
+              </div>
+            </div>
+            <div class="dispatch-comments-show-hide text-center">
+              <span ng-if="vm.isCommentsTruncated && !vm.isShowingAllComments">
+                <a href="#" ng-click="vm.showFullComments(true)">Show All</a>
+              </span>
+              <span ng-if="vm.isCommentsTruncated && vm.isShowingAllComments">
+                <a href="#" ng-click="vm.showFullComments(false)">Hide</a>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Performance Analysis -->
+        <div class="performance-analysis card">
+          <div class="card-header">
+            <h6 class="card-title">StatEngine&trade; Performance Analysis</h6>
+          </div>
+          <div class="card-body">
+            <div class="performance-analysis-items" ng-show="!vm.incident.description.suppressed">
+              <div ng-repeat="analysis in vm.analysis" ng-init="$last && vm.initTippy()">
+                <div
+                  class="card ruletippy h-100"
+                  ng-class="{ 'nfpa-standard': analysis.category === 'NFPA' }"
+                  ng-attr-title="{{ vm.formatEvidence(analysis.evidence) }}"
+                >
+                  <span
+                    ng-class="{
+                      'se-icon-circle-checkmark pass': analysis.grade === 'SUCCESS',
+                      'se-icon-circle-exclamation caution': analysis.grade === 'WARNING',
+                      'se-icon-circle-x fail': analysis.grade === 'DANGER'
+                    }"
+                  ></span>
+                  <h6 class="tx-13 tx-medium mg-b-20">{{ analysis.description }}</h6>
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+      </section>
 
-            <!-- Alarm Answering Duration -->
-            <div class="alarm-answering-duration card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Alarm Answering Duration</h6>
-                <div class="card-option">
-                  <a href="" data-tippy-html='#alarmAnswerTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
-                </div><!-- card-option -->
-              </div><!-- card-header -->
-              <div class="card-body">
-                <incident-alarm-answering-graph incident="vm.incident"></incident-alarm-answering-graph>
+      <!-- Location -->
+      <section class="location" id="location">
+        <!-- Map -->
+        <div class="location-map card">
+          <div class="card-body">
+            <incident-map incidents="[vm.incident]"></incident-map>
+            <div class="location-summary">
+              <dl>
+                <dt>Overview</dt>
+                <dd>{{ vm.textSummaries.locationSummary }}</dd>
+              </dl>
+              <dl>
+                <dt>Address</dt>
+                <dd>
+                  {{ vm.incident.address.address_line1 }} <br>
+                  {{ vm.incident.address.city }}, {{ vm.incident.address.state }}
+                </dd>
+              </dl>
+              <dl>
+                <dt>Response Zone</dt>
+                <dd>
+                  {{ vm.incident.address.response_zone }}
+                </dd>
+              </dl>
+              <dl>
+                <dt>First Due</dt>
+                <dd>
+                  {{ vm.incident.address.first_due }}
+                </dd>
+              </dl>
+              <dl ng-if="vm.incident.address.battalion">
+                <dt>Battalion</dt>
+                <dd>
+                  {{ vm.incident.address.battalion }}
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+
+        <!-- Census Data -->
+        <div class="census-data card">
+          <div class="card-header">
+            <h6 class="card-title">Census Data</h6>
+          </div>
+          <div class="card-body">
+            <div class="d-flex h-100" ng-if="!vm.incident.address.location.census">
+              <div class="no-data">
+                <h5>No census data available.</h5>
+                <a href="#" class="btn btn-alt-2 btn-sm" ui-sref="site.marketplace.home">Request to Add Now</a>
               </div>
             </div>
-
-            <!-- Alarm Processing Duration -->
-            <div class="alarm-processing-duration card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Alarm Processing Duration</h6>
-                <div class="card-option">
-                  <a href="" data-tippy-html='#alarmProcessingTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
-                </div><!-- card-option -->
-              </div><!-- card-header -->
-              <div class="card-body">
-                <incident-alarm-processing-graph incident="vm.incident"></incident-alarm-processing-graph>
+            <div ng-if="vm.incident.address.location.census">
+              <div class="census-data-stats-row">
+                <div class="census-data-stat">
+                  <i class="se-icon-year fa-3x"></i>
+                  <span>
+                    <h2>2010</h2>
+                    <h4>Year</h4>
+                  </span>
+                </div>
+                <div class="census-data-stat" ng-if="vm.incident.address.population_density === 'Urban'">
+                  <i class="se-icon-buildings fa-3x"></i>
+                  <span>
+                    <h2>{{ vm.incident.address.population_density }}</h2>
+                    <h4>Density</h4>
+                  </span>
+                </div>
+                <div class="census-data-stat" ng-if="vm.incident.address.population_density === 'Rural'">
+                  <i class="se-icon-census-tract fa-3x"></i>
+                  <span>
+                    <h2>{{ vm.incident.address.population_density }}</h2>
+                    <h4>Density</h4>
+                  </span>
+                </div>
               </div>
-            </div>
-
-            <!-- Travel Distances -->
-            <div class="travel-distances card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Travel Distances</h6>
-                <div class="card-option">
-                  <a href="" data-tippy-html='#travelDistanceTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
-                </div><!-- card-option -->
-              </div><!-- card-header -->
-              <div class="card-body">
-                <incident-unit-travel-distance-graph incident="vm.incident" travel-matrix="vm.travelMatrix"></incident-unit-travel-distance-graph>
-              </div>
-            </div>
-
-            <!-- Travel Durations -->
-            <div class="travel-durations card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Travel Durations</h6>
-                <div class="card-option">
-                  <a href="" data-tippy-html='#travelDurationTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
-                </div><!-- card-option -->
-              </div><!-- card-header -->
-              <div class="card-body">
-                <incident-unit-travel-duration-graph incident="vm.incident" travel-matrix="vm.travelMatrix"></incident-unit-travel-duration-graph>
-              </div>
-            </div>
-
-            <!-- Response Duration -->
-            <div class="response-duration card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Response Duration</h6>
-                <div class="card-option">
-                  <a href="" data-tippy-html='#responseDurationTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
-                </div><!-- card-option -->
-              </div><!-- card-header -->
-              <div class="card-body">
-                <incident-unit-response-graph incident="vm.incident"></incident-unit-response-graph>
-              </div>
-            </div>
-
-            <!-- Response Duration Comparisons -->
-            <div class="response-duration-comparisons card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Response Duration Comparisons</h6>
-                <div class="card-option">
-                  <a href="" data-tippy-html='#responseDurationComparisonTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
-                </div><!-- card-option -->
-              </div><!-- card-header -->
-              <div class="card-body">
-                <incident-comparison-graph incident="vm.incident" comparison="vm.comparison"></incident-comparison-graph>
-              </div>
-            </div>
-
-            <!-- Concurrent Incidents -->
-            <div class="concurrent-incidents card">
-              <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h6 class="card-title tx-medium mg-b-0 tx-spacing-1">Concurrent Incidents</h6>
-              </div><!-- card-header -->
-              <div class="card-body">
-                <p class="card-subtitle tx-normal mg-b-15">There were <span class="badge badge-secondary tx-14">
-                  {{ vm.concurrentIncidents.length }} </span> incidents also in
-                  progress during this timeframe</p>
-                <div class="concurrent-incidents-table" ui-grid="vm.concurrentIncidentTableOptions">
-                  <div class="watermark" ng-show="!vm.concurrentIncidentTableOptions.data.length">
-                    No concurrent incidents
-                  </div>
+              <div class="census-data-stats-row">
+                <div class="census-data-stat">
+                  <i class="se-icon-census-tract fa-3x"></i>
+                  <span>
+                    <h2>{{ vm.incident.address.location.census.census_2010.tract }}</h2>
+                    <h4>Tract</h4>
+                  </span>
+                </div>
+                <div class="census-data-stat">
+                  <i class="se-icon-census-block fa-3x"></i>
+                  <span>
+                    <h2>{{ vm.incident.address.location.census.census_2010.block }}</h2>
+                    <h4>Block</h4>
+                  </span>
                 </div>
               </div>
             </div>
-          </section>
+          </div>
+        </div>
 
-          <section class="response" id="response" ng-show="vm.incident.description.suppressed">
-            <h5>No response data available.</h5>
-          </section>
-        </div> <!-- END: Tab Panes/Content -->
-      </div>
-    </div>
+        <!-- Parcel Data -->
+        <div class="parcel-data card">
+          <div class="card-header">
+            <h6 class="card-title">Parcel Data</h6>
+          </div>
+          <div class="card-body">
+            <div ng-if="vm.incident.address.location.parcel">
+              <div class="parcel-data-stats-row">
+                <div class="parcel-data-stat">
+                  <i class="se-icon-land-use fa-3x"></i>
+                  <span>
+                    <h2>{{ vm.incident.address.location.parcel.land_use }}</h2>
+                    <h4>Land Use</h4>
+                  </span>
+                </div>
+                <div class="parcel-data-stat">
+                  <i class="se-icon-land-area fa-3x"></i>
+                  <span>
+                    <h2><span ng-if="!vm.incident.address.location.parcel.land_area"> - </span> {{
+                      vm.incident.address.location.parcel.land_area | number:0 }}</h2>
+                    <h4>Land Area (ft&sup2;)</h4>
+                  </span>
+                </div>
+              </div>
+              <div class="parcel-data-stats-row">
+                <div class="parcel-data-stat">
+                  <i class="se-icon-dwelling-value fa-3x"></i>
+                  <span>
+                    <h2> {{ vm.incident.address.location.parcel.dwelling_value | currency:"$":0 }} </h2>
+                    <h4>Dwelling Value</h4>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              ng-if="!vm.incident.address.location.parcel"
+              class="d-flex h-100 tx-center"
+            >
+              <h5 class="no-data">
+                <i class="no-data-icon fa fa-bar-chart"></i><br>
+                No parcel data available
+              </h5>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Situational Awareness -->
+      <section class="situational-awareness" id="situationalAwareness">
+        <!-- Weather Conditions -->
+        <div class="weather-conditions card">
+          <div class="card-header">
+            <h6 class="card-title">Weather Conditions</h6>
+          </div>
+          <div class="card-body">
+            <div ng-if="vm.incident.weather.currently">
+              <div class="row">
+                <p class="col-md-12 mb-4">On {{ vm.incident.weather.currently.time |
+                  amTimezone:vm.currentPrincipal.FireDepartment.timezone | amDateFormat:'MMMM D, YYYY HH:mm' }}
+                  the following weather conditions were observed:</p>
+                <div class="col-md-12">
+                  <current-weather weather="vm.incident.weather.currently"></current-weather>
+                </div>
+              </div>
+            </div>
+            <div ng-if="!vm.incident.weather.currently" class="d-flex">
+              <div class="d-flex h-100 tx-center">
+                <h5 class="no-data">
+                  <i class="no-data-icon fa fa-bar-chart"></i><br>
+                  No weather data available at this time.
+                </h5>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Traffic Conditions -->
+        <div class="traffic-conditions card">
+          <div class="card-header">
+            <h6 class="card-title">Traffic Conditions</h6>
+          </div>
+          <div class="card-body">
+            <div class="d-flex h-100 tx-center">
+              <h5 class="no-data">
+                <i class="no-data-icon fa fa-bar-chart"></i><br>
+                No traffic data available
+              </h5>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Response -->
+      <section class="response" id="response" ng-show="!vm.incident.description.suppressed">
+        <!-- Response Overview -->
+        <div class="response-overview card">
+          <div class="card-header">
+            <h6 class="card-title">Overview</h6>
+          </div>
+          <div class="card-body">
+            <div class="response-overview-summary">
+              {{ vm.textSummaries.responseSummary }}
+            </div>
+            <div class="response-overview-stats">
+              <div class="response-overview-stat">
+                <p class="response-overview-stat-label">Call answered in</p>
+                <h4 class="response-overview-stat-value">
+                  {{ vm.humanizeDuration(vm.incident.durations.alarm_answer.seconds*1000) }}
+                </h4>
+              </div>
+              <div class="response-overview-stat">
+                <p class="response-overview-stat-label">First unit dispatched</p>
+                <h4 class="response-overview-stat-value">
+                  {{ vm.humanizeDuration(vm.incident.durations.alarm_processing.seconds*1000) }}
+                </h4>
+              </div>
+              <div class="response-overview-stat">
+                <p class="response-overview-stat-label">First unit on scene</p>
+                <h4 class="response-overview-stat-value">
+                  {{ vm.humanizeDuration(vm.incident.durations.response.minutes*1000*60) }}
+                </h4>
+              </div>
+              <div class="response-overview-stat">
+                <p class="response-overview-stat-label">Resolved in</p>
+                <h4 class="response-overview-stat-value">
+                  {{ vm.humanizeDuration(vm.incident.durations.total_event.minutes*1000*60) }}
+                </h4>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Events Timeline -->
+        <div class="events-timeline card">
+          <div class="card-header">
+            <h6 class="card-title">Events Timeline</h6>
+          </div>
+          <div class="card-body">
+            <incident-timeline
+              incident="vm.incident"
+              timezone="vm.incident.fire_department.timezone"
+            ></incident-timeline>
+            <div class="events-timeline-legend">
+              <div class="alarm-answer">Alarm Answer</div>
+              <div class="alarm-processing">Alarm Processing</div>
+              <div class="turnout-time">Turnout Time</div>
+              <div class="travel-time">Travel Time</div>
+              <div class="intervention-time">Intervention Time</div>
+              <div class="transport">Transport</div>
+              <div class="post-transport">Post Transport</div>
+              <div class="cancelled">Out-of-Service/Cancelled</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Alarm Answering Duration -->
+        <div class="alarm-answering-duration card">
+          <div class="card-header">
+            <h6 class="card-title">Alarm Answering Duration</h6>
+            <div class="card-option">
+              <a href="" data-tippy-html='#alarmAnswerTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+            </div>
+          </div>
+          <div class="card-body">
+            <incident-alarm-answering-graph incident="vm.incident"></incident-alarm-answering-graph>
+          </div>
+        </div>
+
+        <!-- Alarm Processing Duration -->
+        <div class="alarm-processing-duration card">
+          <div class="card-header">
+            <h6 class="card-title">Alarm Processing Duration</h6>
+            <div class="card-option">
+              <a href="" data-tippy-html='#alarmProcessingTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+            </div>
+          </div>
+          <div class="card-body">
+            <incident-alarm-processing-graph incident="vm.incident"></incident-alarm-processing-graph>
+          </div>
+        </div>
+
+        <!-- Travel Distances -->
+        <div class="travel-distances card">
+          <div class="card-header">
+            <h6 class="card-title">Travel Distances</h6>
+            <div class="card-option">
+              <a href="" data-tippy-html='#travelDistanceTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+            </div>
+          </div>
+          <div class="card-body">
+            <incident-unit-travel-distance-graph incident="vm.incident" travel-matrix="vm.travelMatrix"></incident-unit-travel-distance-graph>
+          </div>
+        </div>
+
+        <!-- Travel Durations -->
+        <div class="travel-durations card">
+          <div class="card-header">
+            <h6 class="card-title">Travel Durations</h6>
+            <div class="card-option">
+              <a href="" data-tippy-html='#travelDurationTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+            </div>
+          </div>
+          <div class="card-body">
+            <incident-unit-travel-duration-graph incident="vm.incident" travel-matrix="vm.travelMatrix"></incident-unit-travel-duration-graph>
+          </div>
+        </div>
+
+        <!-- Response Duration -->
+        <div class="response-duration card">
+          <div class="card-header">
+            <h6 class="card-title">Response Duration</h6>
+            <div class="card-option">
+              <a href="" data-tippy-html='#responseDurationTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+            </div>
+          </div>
+          <div class="card-body">
+            <incident-unit-response-graph incident="vm.incident"></incident-unit-response-graph>
+          </div>
+        </div>
+
+        <!-- Response Duration Comparisons -->
+        <div class="response-duration-comparisons card">
+          <div class="card-header">
+            <h6 class="card-title">Response Duration Comparisons</h6>
+            <div class="card-option">
+              <a href="" data-tippy-html='#responseDurationComparisonTippy' class="se-icon-info pull-right tippy tx-22">&nbsp;</a>
+            </div>
+          </div>
+          <div class="card-body">
+            <incident-comparison-graph incident="vm.incident" comparison="vm.comparison"></incident-comparison-graph>
+          </div>
+        </div>
+
+        <!-- Concurrent Incidents -->
+        <div class="concurrent-incidents card">
+          <div class="card-header">
+            <h6 class="card-title">Concurrent Incidents</h6>
+          </div>
+          <div class="card-body">
+            <p class="card-subtitle tx-normal mg-b-15">There were <span class="badge badge-secondary tx-14">
+              {{ vm.concurrentIncidents.length }} </span> incidents also in
+              progress during this timeframe</p>
+            <div class="concurrent-incidents-table" ui-grid="vm.concurrentIncidentTableOptions">
+              <div class="watermark" ng-show="!vm.concurrentIncidentTableOptions.data.length">
+                No concurrent incidents
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="response" id="response" ng-show="vm.incident.description.suppressed">
+        <h5>No response data available.</h5>
+      </section>
+    </div> <!-- END: Tab Panes/Content -->
   </section>
 
   <!--- tooltips -->

--- a/client/app/incident/incident-analysis/incident-analysis.scss
+++ b/client/app/incident/incident-analysis/incident-analysis.scss
@@ -37,9 +37,12 @@
   }
 
   .incident-analysis-content {
-    @extend .container-fluid;
+    @include container-fluid-max-width;
 
-    max-width: 1230px;
+    @include media-breakpoint-down(sm) {
+      padding-left: 0;
+      padding-right: 0;
+    }
 
     @media print {
       display: block;
@@ -59,22 +62,11 @@
       display: grid;
       grid-template-columns: 50%;
       grid-gap: 2rem;
-      padding-top: 2rem;
+      padding-top: 4rem;
+      position: relative;
 
       &:not(:first-child) {
-        @extend .mt-5;
-      }
-
-      > :first-child::before {
-        @extend .tx-13;
-        @extend .tx-spacing-1;
-        @extend .tx-gray-500;
-        @extend .tx-uppercase;
-        @extend .tx-medium;
-        font-family: 'Montserrat', sans-serif;
-        grid-area: section-header;
-        margin-bottom: -1rem;
-        transform: translateY(-200%);
+        margin-top: 2rem;
       }
 
       @include media-breakpoint-down(md) {
@@ -89,6 +81,14 @@
         > :first-child::before {
           grid-area: unset !important;
         }
+      }
+
+      @include media-breakpoint-down(sm) {
+        grid-gap: 25px;
+      }
+
+      @include media-breakpoint-down(xs) {
+        grid-gap: 15px;
       }
 
       @media print {
@@ -111,9 +111,21 @@
         }
       }
 
+      > :first-child::before {
+        @extend .tx-13;
+        @extend .tx-spacing-1;
+        @extend .tx-gray-500;
+        @extend .tx-uppercase;
+        @extend .tx-medium;
+        position: absolute;
+        top: 0;
+        left: 0;
+        font-family: 'Montserrat', sans-serif;
+        transform: translateY(-200%);
+      }
+
       &.overview {
         grid-template-areas:
-          'section-header       section-header'
           'overview-intro       overview-intro'
           'incident-summary     dispatch-comments'
           'performance-analysis performance-analysis';
@@ -125,13 +137,35 @@
         .overview-intro {
           grid-area: overview-intro;
 
+          .card-body {
+            display: flex;
+
+            @include media-breakpoint-down(sm) {
+              flex-direction: column;
+            }
+          }
+
+          logo {
+            margin-bottom: 1rem;
+          }
+
           .overview-intro-summary {
             display: flex;
             flex-direction: column;
             justify-content: center;
+            margin: 0 3rem;
 
-            @media (min-width: 768px) and (max-width: 1200px) {
-              padding-left: 6rem;
+            @include media-breakpoint-down(sm) {
+              margin: 0 1rem;
+            }
+
+            .alert {
+              text-align: center;
+              margin: 0.5rem 3rem;
+
+              @include media-breakpoint-down(xs) {
+                margin: 0.5rem 1rem;
+              }
             }
           }
 
@@ -147,15 +181,48 @@
 
         .incident-summary {
           grid-area: incident-summary;
+
+          .incident-summary-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.6rem 0;
+            border-bottom: solid 1px $border-color;
+
+            &:last-child {
+              border-bottom: none;
+              padding-bottom: 0;
+            }
+
+            .incident-summary-row-label {
+              @extend .light-label;
+              margin-bottom: 0;
+            }
+          }
         }
 
         .dispatch-comments {
           grid-area: dispatch-comments;
           page-break-before: always;
 
-          p {
-            font-family: monospace;
-            font-size: 15px;
+          .dispatch-comments-comment {
+            padding: 0.25rem 0;
+            border-bottom: solid 1px $border-color;
+
+            &::before {
+              content: '•';
+              margin-right: 0.25rem;
+            }
+
+            &:last-child {
+              border-bottom: none;
+            }
+
+            &.truncated {
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+            }
           }
 
           .dispatch-comments-show-hide {
@@ -201,6 +268,39 @@
             }
           }
 
+          .performance-analysis-items {
+            display: flex;
+
+            @include media-breakpoint-down(lg) {
+              flex-direction: column;
+            }
+
+            > * {
+              flex: 1;
+              margin: 0 0.5rem;
+
+              &:first-child {
+                margin-left: 0;
+              }
+
+              &:last-child {
+                margin-right: 0;
+              }
+
+              @include media-breakpoint-down(lg) {
+                margin: 0.5rem 0;
+
+                &:first-child {
+                  margin-top: 0;
+                }
+
+                &:last-child {
+                  margin-bottom: 0;
+                }
+              }
+            }
+          }
+
           .pass {
             color: #85c02f;
           }
@@ -223,7 +323,6 @@
 
       &.location {
         grid-template-areas:
-          'section-header section-header'
           'map            map'
           'census-data    parcel-data';
 
@@ -250,17 +349,35 @@
         .location-map {
           grid-area: map;
 
-          .incident-map {
-            border-right: 1px solid $color-geyser;
-            height: 100%;
-            max-height: 500px;
-            width: 100%;
+          .card-body {
+            display: flex;
+            padding: 0;
 
-            @media (max-width: 768px) {
-              border-bottom: 1px solid $color-geyser;
-              border-right: 0;
-              height: 300px;
+            @include media-breakpoint-down(sm) {
+              flex-direction: column;
             }
+          }
+
+          incident-map {
+            flex: 0 0 66.6%;
+
+            .incident-map {
+              border-right: 1px solid $color-geyser;
+              height: 100%;
+              max-height: 500px;
+              width: 100%;
+
+              @media (max-width: 768px) {
+                border-bottom: 1px solid $color-geyser;
+                border-right: 0;
+                height: 300px;
+              }
+            }
+          }
+
+          .location-summary {
+            flex: 0 0 33.3%;
+            padding: 1rem;
           }
         }
 
@@ -279,7 +396,6 @@
 
       &.situational-awareness {
         grid-template-areas:
-          'section-header     section-header'
           'weather-conditions traffic-conditions';
 
         > :first-child::before {
@@ -330,7 +446,6 @@
 
       &.response {
         grid-template-areas:
-          'section-header           section-header'
           'response-overview        response-overview'
           'events-timeline          events-timeline'
           'alarm-answering-duration alarm-processing-duration'
@@ -344,6 +459,65 @@
 
         .response-overview {
           grid-area: response-overview;
+
+          .card-body {
+            display: flex;
+            flex-wrap: wrap;
+          }
+
+          .response-overview-summary {
+            flex: 0.333;
+            margin-right: 1rem;
+
+            @include media-breakpoint-down(lg) {
+              flex: 0 0 100%;
+              margin-right: 0;
+            }
+          }
+
+          .response-overview-stats {
+            flex: 0.666;
+            display: flex;
+            flex-wrap: wrap;
+
+            @include media-breakpoint-down(lg) {
+              flex: 0 0 100%;
+              margin-top: 1rem;
+            }
+
+            .response-overview-stat {
+              flex: 1;
+              display: flex;
+              flex-direction: column;
+              justify-content: center;
+              align-items: center;
+              padding: 1rem;
+              text-align: center;
+              border-right: solid 1px $border-color;
+
+              &:last-child {
+                border-right: none;
+              }
+
+              @include media-breakpoint-down(xs) {
+                flex: 0 0 50%;
+
+                &:nth-child(even) {
+                  border-right: none;
+                }
+              }
+
+              .response-overview-stat-label {
+                @extend .light-label;
+              }
+
+              .response-overview-stat-value {
+                @extend .tx-info;
+                @extend .tx-normal;
+                margin-bottom: 0;
+              }
+            }
+          }
         }
 
         .events-timeline {
@@ -366,19 +540,16 @@
           }
 
           .events-timeline-legend {
+            display: flex;
+            flex-direction: column;
+            flex-wrap: wrap;
+            height: 3em;
             font-size: 13px;
+            margin-top: 3rem;
 
-            @media (max-width: 991px) {
-              margin: 3rem 3rem 0;
-            }
-
-            li {
-              margin-bottom: .65rem;
-
-              @media (max-width: 991px) {
-                display: block;
-                margin-bottom: .65rem;
-              }
+            > * {
+              margin: 0.5rem;
+              white-space: nowrap;
 
               &::before {
                 content: '\25A0';
@@ -454,18 +625,29 @@
       }
     }
 
-    .no-data-available {
+    .no-data {
       @extend .tx-gray-500;
-      @extend .tx-center;
-      display: flex;
-      justify-content: center;
-      align-items: center;
+      @extend .m-auto;
+      @extend .pd-b-20;
     }
 
-    // Baseline style for statistical units found in the card layout
-    .stat {
-      align-items: center;
+    .no-data-icon {
+      @extend .tx-80;
+      @extend .tx-gray-300;
+      @extend .mg-b-20;
+    }
+
+    .census-data-stats-row,
+    .parcel-data-stats-row {
       display: flex;
+      flex-wrap: wrap;
+    }
+
+    .census-data-stat,
+    .parcel-data-stat {
+      flex: 1 1 50%;
+      display: flex;
+      align-items: center;
       padding: 0 1.5rem 3rem;
 
       @media (max-width: 768px) {

--- a/client/app/incident/incident-analysis/incident-analysis.scss
+++ b/client/app/incident/incident-analysis/incident-analysis.scss
@@ -19,6 +19,13 @@
     }
   }
 
+  .card {
+    .info-icon {
+      float: right;
+      font-size: 22px;
+    }
+  }
+
   .incident-analysis-tabs {
     @extend .ht-md-60;
     @extend .pb-3;
@@ -205,26 +212,6 @@
           grid-area: dispatch-comments;
           page-break-before: always;
 
-          .dispatch-comments-comment {
-            padding: 0.25rem 0;
-            border-bottom: solid 1px $border-color;
-
-            &::before {
-              content: '•';
-              margin-right: 0.25rem;
-            }
-
-            &:last-child {
-              border-bottom: none;
-            }
-
-            &.truncated {
-              white-space: nowrap;
-              overflow: hidden;
-              text-overflow: ellipsis;
-            }
-          }
-
           .dispatch-comments-show-hide {
             @media print {
               display: none;
@@ -396,7 +383,7 @@
 
       &.situational-awareness {
         grid-template-areas:
-          'weather-conditions traffic-conditions';
+          'weather-conditions weather-conditions';
 
         > :first-child::before {
           content: 'Situational Awareness';
@@ -437,10 +424,6 @@
               margin: 0;
             }
           }
-        }
-
-        .traffic-conditions {
-          grid-area: traffic-conditions;
         }
       }
 
@@ -541,56 +524,79 @@
 
           .events-timeline-legend {
             display: flex;
-            flex-direction: column;
-            flex-wrap: wrap;
-            height: 3em;
+            justify-content: center;
             font-size: 13px;
-            margin-top: 3rem;
+            margin-bottom: 1rem;
 
-            > * {
-              margin: 0.5rem;
-              white-space: nowrap;
+            .events-timeline-legend-items {
+              display: flex;
+              justify-content: center;
+              flex-wrap: wrap-reverse;
+              max-width: 46rem;
 
-              &::before {
-                content: '\25A0';
-                font-size: 29px;
-                line-height: 0;
-                margin-right: 0.5rem;
-                position: relative;
-                top: 4px;
+              @include media-breakpoint-down(xs) {
+                justify-content: start;
               }
 
-              &.alarm-answer::before {
-                color: $color-celery;
-              }
+              > * {
+                margin: 0.25rem 0.5rem;
+                white-space: nowrap;
 
-              &.alarm-processing::before {
-                color: $color-wisteria;
-              }
+                @include media-breakpoint-down(xs) {
+                  margin: 0.25rem 0;
+                  flex: 0 0 50%;
+                }
 
-              &.turnout-time::before {
-                color: $color-tulip-tree;
-              }
+                &::before {
+                  content: '\25A0';
+                  font-size: 29px;
+                  line-height: 0;
+                  margin-right: 0.4rem;
+                  position: relative;
+                  top: 4px;
+                }
 
-              &.travel-time::before {
-                color: $color-di-serria;
-              }
+                &.alarm-answer::before {
+                  color: $color-celery;
+                }
 
-              &.intervention-time::before {
-                color: $color-pelorous;
-              }
+                &.alarm-processing::before {
+                  color: $color-wisteria;
+                }
 
-              &.cancelled::before {
-                color: $color-cranberry;
-              }
+                &.turnout-time::before {
+                  color: $color-tulip-tree;
+                }
 
-              &.transport::before {
-                color: $color-pickled-bluewood;
-              }
+                &.travel-time::before {
+                  color: $color-di-serria;
+                }
 
-              &.post-transport::before {
-                color: $color-pale-sky;
+                &.intervention-time::before {
+                  color: $color-pelorous;
+                }
+
+                &.cancelled::before {
+                  color: $color-cranberry;
+                }
+
+                &.transport::before {
+                  color: $color-pickled-bluewood;
+                }
+
+                &.post-transport::before {
+                  color: $color-pale-sky;
+                }
               }
+            }
+          }
+
+          .vis-inner {
+            padding-left: 0;
+
+            @include media-breakpoint-down(xs) {
+              font-size: 0.75rem;
+              padding-right: 12px;
             }
           }
         }

--- a/client/app/incident/incident-search/incident-search.html
+++ b/client/app/incident/incident-search/incident-search.html
@@ -1,21 +1,22 @@
-<div class="br-pageheader">
-  <nav class="breadcrumb pd-0 mg-0 tx-12">
-    <a class="breadcrumb-item" href="index.html">Home</a>
-    <a class="breadcrumb-item" href="#">Reports</a>
-    <span class="breadcrumb-item active">Incidents</span>
-  </nav>
-</div><!-- br-pageheader -->
-<div class="br-pagetitle d-flex justify-content-between flex-wrap">
-  <h2 class="m-0">Incidents</h2>
-  <div class="input-group wd-300">
-    <input
-      class="form-control"
-      type="text"
-      placeholder="Search Incidents"
-      ng-model="vm.searchInputValue"
-      on-enter-pressed="vm.searchButtonClick()"
-    >
-    <span class="input-group-btn">
+<div class="incident-search">
+  <div class="br-pageheader">
+    <nav class="breadcrumb pd-0 mg-0 tx-12">
+      <a class="breadcrumb-item" href="index.html">Home</a>
+      <a class="breadcrumb-item" href="#">Reports</a>
+      <span class="breadcrumb-item active">Incidents</span>
+    </nav>
+  </div><!-- br-pageheader -->
+  <div class="br-pagetitle d-flex justify-content-between flex-wrap">
+    <h2 class="m-0">Incidents</h2>
+    <div class="input-group wd-300">
+      <input
+        class="form-control"
+        type="text"
+        placeholder="Search Incidents"
+        ng-model="vm.searchInputValue"
+        on-enter-pressed="vm.searchButtonClick()"
+      >
+      <span class="input-group-btn">
       <button
         class="btn bd-0 btn-primary py-2 px-3 rounded-0"
         type="button"
@@ -24,21 +25,22 @@
         <i class="fa fa-search"></i>
       </button>
     </span>
+    </div>
+  </div><!-- br-pagetitle -->
+  <div class="br-pagebody">
+    <section>
+      <incidents-table
+        incidents="vm.incidents"
+        ui-grid-column-defs="vm.uiGridColumnDefs"
+        pagination="vm.pagination"
+        sort="vm.sort"
+        is-loading="vm.isLoading"
+        is-loading-first="vm.isLoadingFirst"
+        on-pagination-change="vm.handlePaginationChange()"
+        on-sort-change="vm.handleSortChange()"
+        use-external-pagination="true"
+        use-external-sorting="true"
+      ></incidents-table>
+    </section>
   </div>
-</div><!-- br-pagetitle -->
-<div class="br-pagebody">
-  <section>
-    <incidents-table
-      incidents="vm.incidents"
-      ui-grid-column-defs="vm.uiGridColumnDefs"
-      pagination="vm.pagination"
-      sort="vm.sort"
-      is-loading="vm.isLoading"
-      is-loading-first="vm.isLoadingFirst"
-      on-pagination-change="vm.handlePaginationChange()"
-      on-sort-change="vm.handleSortChange()"
-      use-external-pagination="true"
-      use-external-sorting="true"
-    ></incidents-table>
-  </section>
 </div>

--- a/client/app/incident/incident-search/incident-search.scss
+++ b/client/app/incident/incident-search/incident-search.scss
@@ -1,0 +1,7 @@
+.incident-search {
+  incidents-table {
+    .ui-grid-table {
+      height: 61vh;
+    }
+  }
+}

--- a/client/app/incident/incident.scss
+++ b/client/app/incident/incident.scss
@@ -1,1 +1,2 @@
 @import './incident-analysis/incident-analysis.scss';
+@import './incident-search/incident-search.scss';

--- a/client/app/reporting/reporting-unit/reporting-unit.html
+++ b/client/app/reporting/reporting-unit/reporting-unit.html
@@ -42,45 +42,33 @@
               </select>
             </div>
 
-            <div class="section-tabs">
-              <ul class="nav nav-outline active-info align-items-start flex-column flex-md-row" ng-if="vm.isDataAvailable()">
-                <li class="nav-item tx-medium pl-0">
-                  <a class="nav-link" href="" ng-click="vm.scrollTo('#incidentTypesHeader')">
-                    Incident Types
-                  </a>
-                </li>
-                <li class="nav-item tx-medium">
-                  <a class="nav-link" href="" ng-click="vm.scrollTo('#travelTimeHeader')">
-                    Travel
-                  </a>
-                </li>
-                <li class="nav-item tx-medium">
-                  <a class="nav-link" href="" ng-click="vm.scrollTo('#turnoutTimeHeader')">
-                    Turnout
-                  </a>
-                </li>
-                <li class="nav-item tx-medium">
-                  <a
-                    class="nav-link"
-                    href=""
-                    ng-click="vm.showOverlay('timeline')"
-                    ng-disabled="vm.incidentsTimeline.incidents.length === 0"
-                  >
-                    Timeline
-                  </a>
-                </li>
-                <li class="nav-item tx-medium">
-                  <a
-                    class="nav-link"
-                    href=""
-                    ng-click="vm.showOverlay('incidents')"
-                    ng-disabled="vm.incidentsTable.incidents.length === 0"
-                  >
-                    Incidents
-                  </a>
-                </li>
-              </ul>
-            </div>
+            <nav class="section-nav">
+              <div class="section-nav-links" ng-if="vm.isDataAvailable()">
+                <a href="" ng-click="vm.scrollTo('#incidentTypesHeader')">
+                  Incident Types
+                </a>
+                <a href="" ng-click="vm.scrollTo('#travelTimeHeader')">
+                  Travel
+                </a>
+                <a href="" ng-click="vm.scrollTo('#turnoutTimeHeader')">
+                  Turnout
+                </a>
+                <a
+                  href=""
+                  ng-click="vm.showOverlay('timeline')"
+                  ng-disabled="vm.incidentsTimeline.incidents.length === 0"
+                >
+                  Timeline
+                </a>
+                <a
+                  href=""
+                  ng-click="vm.showOverlay('incidents')"
+                  ng-disabled="vm.incidentsTable.incidents.length === 0"
+                >
+                  Incidents
+                </a>
+              </div>
+            </nav>
 
             <div class="card-body bg-white" ng-if="!vm.isDataAvailable()">
               <h2>No Data Available</h2>

--- a/client/app/reporting/reporting-unit/reporting-unit.scss
+++ b/client/app/reporting/reporting-unit/reporting-unit.scss
@@ -81,18 +81,6 @@
       width: 10rem;
     }
 
-    .section-tabs {
-      display: flex;
-      align-items: center;
-      justify-content: start;
-      padding: 1rem 25px 0;
-      border-bottom: solid 1px $input-border-color;
-
-      @include media-breakpoint-down(xs) {
-        padding: 1rem 15px 0;
-      }
-    }
-
     .card {
       margin: 1rem 0;
     }

--- a/client/app/twitter/twitter-home/twitter-home.html
+++ b/client/app/twitter/twitter-home/twitter-home.html
@@ -56,7 +56,7 @@
     <div class="row twitter-account-info">
       <div class="col-lg-12 mb-3">
         <div class="card">
-          <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
+          <div class="card-header">
             <h6>Twitter Account Info</h6>
           </div>
           <div class="card-body">
@@ -82,7 +82,7 @@
     <div class="row recommendations">
       <div class="col-lg-12 mb-3">
         <div class="card tweet-card">
-          <h6 class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">Tweet Recommendations</h6>
+          <h6 class="card-header">Tweet Recommendations</h6>
 
           <div class="card-body">
             <div ng-if="!vm.recommendedTweets || vm.recommendedTweets.length === 0" class="text-warning">
@@ -122,7 +122,7 @@
     <div class="row mt-1 recent-activity">
       <div class="col-lg-12">
         <div class="card">
-          <h6 class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">Recent Activity</h6>
+          <h6 class="card-header">Recent Activity</h6>
 
 
           <div class="card-body">

--- a/client/app/user/user-home/user-home.html
+++ b/client/app/user/user-home/user-home.html
@@ -76,8 +76,8 @@
       <div class="row">
         <div class="col-sm-6 weather-conditions">
           <div class="card h-100">
-            <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-              <h2 class="card-title tx-medium mg-b-0 tx-spacing-1">Today</h2>
+            <div class="card-header">
+              <h2 class="card-title">Today</h2>
               <div class="card-option">
                 <h3 class="heavyheader"> <shift-text firecares_id="{{vm.fireDepartment.firecares_id}}" timezone="{{vm.fireDepartment.timezone}}"> </shift-text></h3>
               </div><!-- card-option -->
@@ -109,8 +109,8 @@
         </div>
         <div class="col-sm-6">
           <div class="card h-100">
-            <div class="card-header bg-white bd-0 d-flex align-items-center justify-content-between">
-                <h2 class="card-title tx-medium mg-b-0 tx-spacing-1">Yesterday's Recap</h2>
+            <div class="card-header">
+                <h2 class="card-title">Yesterday's Recap</h2>
               <div class="card-option">
                 <h3 class="heavyheader"> <shift-text firecares_id="{{vm.fireDepartment.firecares_id}}" timezone="{{vm.fireDepartment.timezone}}" days_ago=1> </shift-text></h3>
               </div><!-- card-option -->

--- a/client/app/user/user-home/user-home.html
+++ b/client/app/user/user-home/user-home.html
@@ -74,7 +74,7 @@
   <div class="br-pagebody">
     <section class="overview">
       <div class="row">
-        <div class="col-sm-6 weather-conditions">
+        <div class="col-md-6 weather-conditions">
           <div class="card h-100">
             <div class="card-header">
               <h2 class="card-title">Today</h2>
@@ -107,7 +107,7 @@
             </div>
           </div>
         </div>
-        <div class="col-sm-6">
+        <div class="col-md-6">
           <div class="card h-100">
             <div class="card-header">
                 <h2 class="card-title">Yesterday's Recap</h2>

--- a/client/app/user/user-settings/user-settings.html
+++ b/client/app/user/user-settings/user-settings.html
@@ -52,8 +52,10 @@
     <!-- My Profile -->
     <div class="tab-pane fade show active" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
       <div class="card mg-b-25">
+        <div class="card-header mb-3">
+          <h6 class="card-title">My Profile</h6>
+        </div>
         <div class="card-body">
-          <h6 class="card-title tx-spacing-1 tx-medium mg-b-35">My Profile</h6>
           <form name="profileForm" id="profileForm" ng-submit="vm.saveProfile(profileForm)" novalidate>
             <div class="form-layout">
               <div class="row">
@@ -106,8 +108,10 @@
     <!-- Email -->
     <div class="tab-pane fade" id="nav-email" role="tabpanel" aria-labelledby="nav-email-tab">
       <div class="card mg-b-25">
+        <div class="card-header mb-3">
+          <h6 class="card-title">Email</h6>
+        </div>
         <div class="card-body">
-          <h6 class="card-title tx-spacing-1 tx-medium mg-b-35">Email</h6>
           <form name="emailForm" id="emailForm" ng-submit="vm.saveEmail(emailForm)" novalidate>
             <div class="form-layout">
               <div class="row" ng-repeat="reportName in vm.reportNames">
@@ -155,11 +159,13 @@
 
     <div class="tab-pane fade " id="nav-password" role="tabpanel" aria-labelledby="nav-password-tab">
       <div class="card mg-b-25 tab-pane" role="tabpanel">
+        <div class="card-header mb-3">
+          <h6 class="card-title">Password</h6>
+        </div>
         <div class="card-body">
-          <h6 class="card-title tx-spacing-1 tx-medium mg-b-35">Password</h6>
           <form name="passwordForm" id="passwordForm" ng-submit="vm.changePassword(passwordForm)" novalidate>
             <div class="form-layout">
-              <div class="row mg-t-30 mg-b-15">
+              <div class="row mg-b-15">
                 <div class="col-lg-4">
                   <div class="form-group">
                     <label class="form-control-label">Current Password:

--- a/client/components/incident/incident-alarm-answering-graph.component.js
+++ b/client/components/incident/incident-alarm-answering-graph.component.js
@@ -82,7 +82,7 @@ export default class IncidentAlarmAnsweringGraphComponent {
     const layout = {
       barmode: 'overlay',
       shapes,
-      height: 290,
+      height: 320,
       margin: {
         l: 5,
         r: 5,

--- a/client/components/incident/incident-alarm-processing-graph.component.js
+++ b/client/components/incident/incident-alarm-processing-graph.component.js
@@ -83,7 +83,7 @@ export default class IncidentAlarmProcessingGraphComponent {
     const layout = {
       barmode: 'overlay',
       shapes,
-      height: 290,
+      height: 320,
       margin: {
         l: 5,
         r: 5,

--- a/client/components/incident/incident-comparison-graph.component.js
+++ b/client/components/incident/incident-comparison-graph.component.js
@@ -94,7 +94,7 @@ export default class IncidentComparisonGraphComponent {
           color: '#e91276'
         },
       }],
-      height: 290,
+      height: 320,
       margin: {
         l: 100,
         r: 2,
@@ -108,6 +108,13 @@ export default class IncidentComparisonGraphComponent {
       },
       yaxis: {
         linecolor: '#d7dee3',
+      },
+      legend: {
+        orientation: 'h',
+        xanchor: 'center',
+        yanchor: 'bottom',
+        x: 0.5,
+        y: 1.05,
       },
     }, {
       displayModeBar: false,

--- a/client/components/incident/incident-unit-response-graph.component.js
+++ b/client/components/incident/incident-unit-response-graph.component.js
@@ -93,7 +93,7 @@ export default class IncidentUnitResponseGraphComponent {
     const layout = {
       barmode: 'stack',
       shapes,
-      height: 290,
+      height: 320,
       margin: {
         l: 55,
         r: 5,
@@ -105,6 +105,13 @@ export default class IncidentUnitResponseGraphComponent {
         title: 'Seconds',
         linecolor: '#d7dee3',
         zerolinecolor: '#d7dee3',
+      },
+      legend: {
+        orientation: 'h',
+        xanchor: 'center',
+        yanchor: 'bottom',
+        x: 0.5,
+        y: 1.05,
       },
       annotations: [{
         x: threshold,

--- a/client/components/incident/incident-unit-travel-distance-graph.component.js
+++ b/client/components/incident/incident-unit-travel-distance-graph.component.js
@@ -66,7 +66,7 @@ export default class IncidentUnitTravelDistanceGraphComponent {
 
       var data = [estimatedTrace];
       var layout = {
-        height: 290,
+        height: 320,
         margin: {
           l: 40,
           r: 1,

--- a/client/components/incident/incident-unit-travel-duration-graph.component.js
+++ b/client/components/incident/incident-unit-travel-duration-graph.component.js
@@ -75,7 +75,7 @@ export default class IncidentUnitTravelDurationGraphComponent {
     data.push(actualTrace);
 
     var layout = {
-      height: 290,
+      height: 320,
       shapes,
       annotations,
       margin: {
@@ -93,7 +93,13 @@ export default class IncidentUnitTravelDurationGraphComponent {
         title: 'Seconds',
         linecolor: '#d7dee3',
       },
-
+      legend: {
+        orientation: 'h',
+        xanchor: 'center',
+        yanchor: 'bottom',
+        x: 0.5,
+        y: 1.05,
+      },
     };
     PlotlyBasic.newPlot(this.id, data, layout, {
       displayModeBar: false,

--- a/client/components/incidents-table/incidents-table.component.html
+++ b/client/components/incidents-table/incidents-table.component.html
@@ -1,7 +1,7 @@
 <div ng-if="vm.initialized">
   <div class="incidents-table-desktop">
     <div
-      class="search-grid"
+      class="ui-grid-table"
       ui-grid="vm.uiGridOptions"
       ui-grid-resize-column
     >
@@ -15,6 +15,7 @@
     </div>
 
     <table-controls
+      ng-if="vm.showControls"
       pagination="vm.pagination"
       on-pagination-change="vm.handlePaginationChange({ pagination })"
       position="bottom"
@@ -25,6 +26,7 @@
   <!-- Incidents (mobile) -->
   <div class="incidents-table-mobile">
     <table-controls
+      ng-if="vm.showControls"
       pagination="vm.pagination"
       sort="vm.sortSelect"
       on-pagination-change="vm.handlePaginationChange({ pagination })"
@@ -62,7 +64,7 @@
     </div>
 
     <table-controls
-      ng-if="!vm.isLoadingFirst"
+      ng-if="vm.showControls && !vm.isLoadingFirst"
       pagination="vm.pagination"
       sort="vm.sortSelect"
       on-pagination-change="vm.handlePaginationChange({ pagination })"

--- a/client/components/incidents-table/incidents-table.component.js
+++ b/client/components/incidents-table/incidents-table.component.js
@@ -8,6 +8,7 @@ let _;
 export class IncidentsTableController {
   incidents;
   uiGridColumnDefs;
+  onUiGridInit;
   pagination;
   sort;
   isLoading;
@@ -16,6 +17,8 @@ export class IncidentsTableController {
   onSortChange;
   useExternalPagination;
   useExternalSorting;
+  showControls;
+  minRowsToShow;
 
   initialized = false;
   sortSelect;
@@ -34,6 +37,8 @@ export class IncidentsTableController {
 
   async $onInit() {
     await this.loadModules();
+
+    this.showControls = (!_.isUndefined(this.showControls)) ? this.showControls : true;
 
     if(!this.pagination) {
       this.pagination = {
@@ -81,6 +86,7 @@ export class IncidentsTableController {
       useExternalPagination: this.useExternalPagination,
       useExternalSorting: this.useExternalSorting,
       enableHorizontalScrollbar: false,
+      minRowsToShow: this.minRowsToShow,
       onRegisterApi: (uiGridApi) => {
         this.uiGridApi = uiGridApi;
         uiGridApi.core.on.sortChanged(this.$scope, (uiGrid, sortColumns) => {
@@ -91,8 +97,16 @@ export class IncidentsTableController {
           this.sortSelect.selectedColumn = this.sort.columns[0];
           this.fireOnSortChange();
         });
+
+        if (this.onUiGridInit) {
+          this.onUiGridInit({ uiGridApi });
+        }
       },
     };
+
+    this.$scope.$watch('minRowsToShow', () => {
+      this.uiGridOptions.minRowsToShow = this.minRowsToShow;
+    });
 
     // In sort select only show columns with sorting enabled.
     this.sortSelect.columnDefs = this.uiGridOptions.columnDefs.filter((columnDef) => {
@@ -172,6 +186,7 @@ export default angular.module('incidentsTable', [tableControls])
     bindings: {
       incidents: '<',
       uiGridColumnDefs: '<',
+      onUiGridInit: '&?',
       pagination: '=?',
       sort: '=?',
       isLoading: '<?',
@@ -180,6 +195,8 @@ export default angular.module('incidentsTable', [tableControls])
       onSortChange: '&?',
       useExternalPagination: '<?',
       useExternalSorting: '<?',
+      showControls: '<?',
+      minRowsToShow: '<?',
     },
   })
   .name

--- a/client/components/incidents-table/incidents-table.scss
+++ b/client/components/incidents-table/incidents-table.scss
@@ -4,18 +4,12 @@ incidents-table {
       display: none;
     }
 
-    .search-grid {
-      height: 61vh;
-
+    .ui-grid-table {
       .ui-grid-top-panel {
         background-color: white;
         color: #adb2b7;
         text-transform: uppercase;
         font-size: 12px;
-
-        .ui-grid-cell-contents {
-          padding: 10px;
-        }
       }
 
       .ui-grid-row:nth-child(odd):not(:hover) .ui-grid-cell {

--- a/client/components/weather/current-weather.component.html
+++ b/client/components/weather/current-weather.component.html
@@ -1,27 +1,22 @@
-<div class="row">
-  <div class="col-sm-5">
-    <div class="weather-cube">
-      <skycon icon="vm.weather.icon" size="110"></skycon>
-      <h3> {{ vm.textSummaries.situationalAwarenessSummary }}</h3>
-    </div>
-  </div>
-  <div class="col-sm-7 weather-summary">
-    <h1 class="heavyheader"> {{ vm.weather.temperature | number : 0 }} &deg;</h1>
-    <h4>{{ vm.incident.description.day_of_week }}</h4>
-    <hr>
-    <div>
-      <label class="tx-semibold">Feels Like:</label>
-      <span>{{ vm.weather.apparentTemperature | number : 0  }} &deg;</span>
-    </div>
+<div class="weather-cube">
+  <skycon icon="vm.weather.icon" size="110"></skycon>
+  <h3> {{ vm.textSummaries.situationalAwarenessSummary }}</h3>
+</div>
 
-    <div ng-if="vm.weather.precipProbability">
-      <label class="tx-semibold">Precipitation:</label>
-      <span>{{ vm.weather.precipProbability*100 | number : 0 }}% chance of {{ vm.weather.precipType }}</span>
-    </div>
-
-    <div>
-      <label class="tx-semibold">Wind:</label>
-      <span>{{ vm.weather.windSpeed | number : 0 }} mph with gusts up to {{ vm.weather.windGust | number : 0  }} mph</span>
-    </div>
-  </div>
+<div class="weather-summary">
+  <h1 class="heavyheader"> {{ vm.weather.temperature | number : 0 }} &deg;</h1>
+  <h4>{{ vm.incident.description.day_of_week }}</h4>
+  <hr>
+  <dl>
+    <dt>Feels Like</dt>
+    <dd>{{ vm.weather.apparentTemperature | number : 0  }} &deg;</dd>
+  </dl>
+  <dl ng-if="vm.weather.precipProbability">
+    <dt>Precipitation</dt>
+    <dd>{{ vm.weather.precipProbability*100 | number : 0 }}% chance of {{ vm.weather.precipType }}</dd>
+  </dl>
+  <dl>
+    <dt>Wind</dt>
+    <dd>{{ vm.weather.windSpeed | number : 0 }} mph with gusts up to {{ vm.weather.windGust | number : 0  }} mph</dd>
+  </dl>
 </div>

--- a/client/components/weather/current-weather.scss
+++ b/client/components/weather/current-weather.scss
@@ -1,0 +1,21 @@
+current-weather {
+  display: flex;
+
+  @include media-breakpoint-down(xs) {
+    flex-direction: column;
+  }
+
+  .weather-cube {
+    flex: 0.4;
+    margin-right: 1rem;
+
+    @include media-breakpoint-down(xs) {
+      margin-right: 0;
+      margin-bottom: 1rem;
+    }
+  }
+
+  .weather-summary {
+    flex: 0.6;
+  }
+}

--- a/server/api/incident/mapbox.helpers.js
+++ b/server/api/incident/mapbox.helpers.js
@@ -33,35 +33,35 @@ export const getMatrix = async incident => {
     return results;
   }
 
-  await Promise.map(_.chunk(pairs, 24), async splitPairs => {
-    // Add destination.
-    splitPairs.push({ longitude, latitude });
-
-    const coordinates = _.map(splitPairs, p => `${p.longitude},${p.latitude}`).join(';');
-    const options = {
-      uri: `https://api.mapbox.com/directions-matrix/v1/mapbox/driving/${coordinates}`,
-      qs: {
-        access_token: config.mapbox.token,
-        annotations: 'distance,duration'
-      },
-      json: true,
-    };
-
-    let destinationIndex = splitPairs.length - 1;
-    const body = await rp(options);
-
-    if(_.isEmpty(body) || _.isEmpty(body.distances) || _.isEmpty(body.durations)) {
-      throw new Error('Unknown format from mapbox');
-    }
-    for(let i = 0; i < destinationIndex; i += 1) {
-      let unit = splitPairs[i].unit_id;
-      if(!results[unit]) results[unit] = {};
-
-      // use mapbox distance if not set by cad
-      if(!results[unit].distance) results[unit].distance = body.distances[i][destinationIndex] * 0.000621371;
-      results[unit].duration = body.durations[i][destinationIndex];
-    }
-  });
+  // await Promise.map(_.chunk(pairs, 24), async splitPairs => {
+  //   // Add destination.
+  //   splitPairs.push({ longitude, latitude });
+  //
+  //   const coordinates = _.map(splitPairs, p => `${p.longitude},${p.latitude}`).join(';');
+  //   const options = {
+  //     uri: `https://api.mapbox.com/directions-matrix/v1/mapbox/driving/${coordinates}`,
+  //     qs: {
+  //       access_token: config.mapbox.token,
+  //       annotations: 'distance,duration'
+  //     },
+  //     json: true,
+  //   };
+  //
+  //   let destinationIndex = splitPairs.length - 1;
+  //   const body = await rp(options);
+  //
+  //   if(_.isEmpty(body) || _.isEmpty(body.distances) || _.isEmpty(body.durations)) {
+  //     throw new Error('Unknown format from mapbox');
+  //   }
+  //   for(let i = 0; i < destinationIndex; i += 1) {
+  //     let unit = splitPairs[i].unit_id;
+  //     if(!results[unit]) results[unit] = {};
+  //
+  //     // use mapbox distance if not set by cad
+  //     if(!results[unit].distance) results[unit].distance = body.distances[i][destinationIndex] * 0.000621371;
+  //     results[unit].duration = body.durations[i][destinationIndex];
+  //   }
+  // });
 
   return results;
 };

--- a/server/api/incident/mapbox.helpers.js
+++ b/server/api/incident/mapbox.helpers.js
@@ -33,35 +33,35 @@ export const getMatrix = async incident => {
     return results;
   }
 
-  // await Promise.map(_.chunk(pairs, 24), async splitPairs => {
-  //   // Add destination.
-  //   splitPairs.push({ longitude, latitude });
-  //
-  //   const coordinates = _.map(splitPairs, p => `${p.longitude},${p.latitude}`).join(';');
-  //   const options = {
-  //     uri: `https://api.mapbox.com/directions-matrix/v1/mapbox/driving/${coordinates}`,
-  //     qs: {
-  //       access_token: config.mapbox.token,
-  //       annotations: 'distance,duration'
-  //     },
-  //     json: true,
-  //   };
-  //
-  //   let destinationIndex = splitPairs.length - 1;
-  //   const body = await rp(options);
-  //
-  //   if(_.isEmpty(body) || _.isEmpty(body.distances) || _.isEmpty(body.durations)) {
-  //     throw new Error('Unknown format from mapbox');
-  //   }
-  //   for(let i = 0; i < destinationIndex; i += 1) {
-  //     let unit = splitPairs[i].unit_id;
-  //     if(!results[unit]) results[unit] = {};
-  //
-  //     // use mapbox distance if not set by cad
-  //     if(!results[unit].distance) results[unit].distance = body.distances[i][destinationIndex] * 0.000621371;
-  //     results[unit].duration = body.durations[i][destinationIndex];
-  //   }
-  // });
+  await Promise.map(_.chunk(pairs, 24), async splitPairs => {
+    // Add destination.
+    splitPairs.push({ longitude, latitude });
+
+    const coordinates = _.map(splitPairs, p => `${p.longitude},${p.latitude}`).join(';');
+    const options = {
+      uri: `https://api.mapbox.com/directions-matrix/v1/mapbox/driving/${coordinates}`,
+      qs: {
+        access_token: config.mapbox.token,
+        annotations: 'distance,duration'
+      },
+      json: true,
+    };
+
+    let destinationIndex = splitPairs.length - 1;
+    const body = await rp(options);
+
+    if(_.isEmpty(body) || _.isEmpty(body.distances) || _.isEmpty(body.durations)) {
+      throw new Error('Unknown format from mapbox');
+    }
+    for(let i = 0; i < destinationIndex; i += 1) {
+      let unit = splitPairs[i].unit_id;
+      if(!results[unit]) results[unit] = {};
+
+      // use mapbox distance if not set by cad
+      if(!results[unit].distance) results[unit].distance = body.distances[i][destinationIndex] * 0.000621371;
+      results[unit].duration = body.durations[i][destinationIndex];
+    }
+  });
 
   return results;
 };


### PR DESCRIPTION
The incident analysis page should be fully responsive now without any breaking UI elements across all screen widths. I also did some general cleanup of element classes for easier maintainability and readability, and tried to move away from bootstrap row/column layouts to allow more flexible css-based layouts and simpler html.

I redid the section nav links (Overview, Location, etc) at the top of the page so that they're no longer tabs (since tabs didn't really make sense there), and so that they match the Units page.

The graph legends have been repositioned to sit on top of each graph, since that's where I generally expect to see them, and since they need to be on top anyways down at mobile screen widths. It also keeps the graphs from getting too squashed when they're positioned side by side.

The concurrent incidents table should now switch to the cards layout at smaller screen widths to prevent the data from getting cut off.

I also made several minor positioning/padding adjustments, but probably nothing particularly noticeable. Just small polish tweaks.

Let me know if anything looks weird or breaks for you!