### PR TITLE
Base layout tweaks.

### DIFF
--- a/client/app.template.html
+++ b/client/app.template.html
@@ -25,7 +25,11 @@
       <div class="sidebar-view" ui-view="sidebar"></div>
       <div class="app-view">
         <div class="appbar-view" ui-view="appbar"></div>
-        <div class="content-view" ui-view="content"></div>
+        <div class="app-content-container">
+          <div class="app-content">
+            <div class="app-content-view" ui-view="content"></div>
+          </div>
+        </div>
       </div>
     </div>
     <div ui-view="landing"></div>

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -134,15 +134,32 @@ body {
   }
 }
 
-.content-view {
-  @extend .medium-bg;
-  @extend .ios-scroll-fix;
+.app-content-container {
+  // This container and its child are a workaround to allow the content view to escape
+  // from the flexbox layout, so that descendants can size using height percentages
+  // if need be. It also fixes some auto-resizing issues.
+  position: relative;
   flex: 1;
-  overflow: auto;
 
-  @media print {
-    display: block;
-    overflow: visible;
+  .app-content {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+
+    @media print {
+      height: auto;
+    }
+
+    .app-content-view {
+      @extend .medium-bg;
+      @extend .ios-scroll-fix;
+      height: 100%;
+      overflow: auto;
+
+      @media print {
+        overflow: visible;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This is a slightly hacky feeling tweak, but as far as I can tell it has no downsides and it works in all major browsers. It fixes an issue that's haunted me ever since the base layout revamp, where sizing page elements with height percentages no longer worked. 

Interestingly, this also fixes an issue where the incidents search table wouldn't resize automatically when shrinking the browser width (expanding worked fine strangely). So it seems to be a healthier layout for preventing downstream glitches.