### PR TITLE
Fix department access email links.

### DIFF
--- a/server/api/user/user.controller.js
+++ b/server/api/user/user.controller.js
@@ -165,10 +165,10 @@ async function sendRequestDepartmentAccessEmail(user, department) {
           content: user.last_name,
         }, {
           name: 'APPROVE_ACCESS_URL',
-          content: `http://localhost:3000/departmentAdmin?action=approve_access&action_username=${user.username}`,
+          content: `https://statengine.io/departmentAdmin?action=approve_access&action_username=${user.username}`,
         }, {
           name: 'REJECT_ACCESS_URL',
-          content: `http://localhost:3000/departmentAdmin?action=revoke_access&action_username=${user.username}`,
+          content: `https://statengine.io/departmentAdmin?action=revoke_access&action_username=${user.username}`,
         }],
       },
     },


### PR DESCRIPTION
These links got committed with localhost addresses somehow, leading production users to a dead end. They should work properly now.

I'll get a better setup for this using development environment settings to avoid the issue in the future.