### PR TITLE
Exclude fixture template files in gulp server scripts paths.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -45,7 +45,8 @@ const paths = {
     server: {
         scripts: [
           `${serverPath}/**/!(*.spec|*.integration).js`,
-          `!${serverPath}/config/local.env.sample.js`
+          `!${serverPath}/config/local.env.sample.js`,
+          `!${serverPath}/fixtures/templates/**/*`
         ],
         json: [`${serverPath}/**/*.json`],
         templates: [`${serverPath}/api/incident/templates`],


### PR DESCRIPTION
The build should be working again with this fix.