### PR TITLE
update label for confirm password form element

### DIFF
--- a/client/app/user/user-settings/user-settings.html
+++ b/client/app/user/user-settings/user-settings.html
@@ -182,7 +182,7 @@
                     <input type="password" id="password1" name="password1" data-parsley-minlength="8" data-parsley-uppercase="1" data-parsley-lowercase="1" data-parsley-number="1" required class="form-control" ng-model="vm.password.inputs.newPassword" mongoose-error="mongoose-error"/>
                   </div>
                   <div class="form-group">
-                    <label class="form-control-label">Confirm Password:
+                    <label class="form-control-label">Retype New Password:
                         <span class="tx-danger">*</span></label>
                     <input type="password" id="password2" name="password2" data-parsley-equalto="#password1" required class="form-control" ng-model="vm.password.inputs.newPasswordRepeat" mongoose-error="mongoose-error"/>
                   </div>


### PR DESCRIPTION
## Prelude
#234 Issue suggest updating the label to `Repeat New Password` but based on my findings `Retype New Password` conforms more to the current UX standards.
<img width="792" alt="Screenshot 2019-09-03 at 16 06 15" src="https://user-images.githubusercontent.com/6104164/64182431-87191780-ce68-11e9-9e9b-2bc86268ee46.png">

## Issues
- #234 

## List of Changes
- Updated the label based on UX standards

## Screenshots
<img width="859" alt="Screenshot 2019-09-03 at 16 31 12" src="https://user-images.githubusercontent.com/6104164/64182464-9009e900-ce68-11e9-925d-5d9f7fe50264.png">
