### PR TITLE
additional condition to remove flashing of stat engine logo

### DIFF
--- a/client/components/sidebar/sidebar.html
+++ b/client/components/sidebar/sidebar.html
@@ -1,11 +1,11 @@
 <div class="root" ng-class="vm.theme">
   <div class="sidebar-overlay" ng-click="vm.hideSidebar()"></div>
 
-  <div class="logo-container" ng-if="vm.theme === 'nfors'">
+  <div class="logo-container" ng-show="!!vm.theme" ng-if="vm.theme === 'nfors'">
     <img class="logo-expanded" src="/assets/images/nfors-branding.png" alt="logo">
     <img class="logo-collapsed" src="/assets/images/nfors-branding-symbol.png" alt="logo">
   </div>
-  <div class="logo-container" ng-if="vm.theme !== 'nfors'">
+  <div class="logo-container" ng-show="!!vm.theme" ng-if="vm.theme !== 'nfors'">
     <img class="logo-expanded" src="/assets/images/branding-alt.svg" alt="logo">
     <img class="logo-collapsed" src="/assets/images/branding-symbol.svg" alt="logo">
   </div>


### PR DESCRIPTION
## Prelude
**StatEngine** logo is rendered if `vm.theme` attribute is not yet available regardless of its value.

## Issues
- #142 

## List of Changes
- Used `ng-show` directive to display logos only if the `theme` attribute in the `vm` namespace is available due to possible race condition during loading.

## Screenshots
![ezgif com-video-to-gif (17)](https://user-images.githubusercontent.com/6104164/64186167-a9159880-ce6e-11e9-95e1-4da563637782.gif)
