### PR TITLE
add active class to dashboard menu item

### DIFF
--- a/client/components/sidebar/sidebar.html
+++ b/client/components/sidebar/sidebar.html
@@ -22,7 +22,7 @@
           </a>
         </li>
         <li class="br-menu-item" ng-show="vm.user.fire_department__id">
-          <a href="#" ng-click='vm.dashboard()' class="br-menu-link">
+          <a href="#" ng-class="{ active: vm.$state.current.name == 'site.workspace.home' }" ng-click='vm.dashboard()' class="br-menu-link">
             <i class="menu-item-icon fa fa-dashboard tx-20"></i>
             <span class="menu-item-label text-truncate">Dashboard</span>
           </a>


### PR DESCRIPTION
## Prelude
Dashboard menu item looses the highlighted status when the user clicked anywhere on the screen after navigating to Workspaces.

## Issues
- #309 

## List of Changes
- Added `active` class to **Dashboard** menu item if that's the active navigation route.

## Screenshots
<img width="1014" alt="Screenshot 2019-09-04 at 19 24 12" src="https://user-images.githubusercontent.com/6104164/64277222-1e09d080-cf4a-11e9-81cd-ccc72d935184.png">
