### PR TITLE
Fix missing graph in unit timeline in Edge.

### DIFF
--- a/client/app/reporting/reporting-unit/reporting-unit.controller.js
+++ b/client/app/reporting/reporting-unit/reporting-unit.controller.js
@@ -131,6 +131,12 @@ export default class ReportingUnitController {
     this.$scope.$on('$destroy', () => {
       this.removeResizeEventListener();
     });
+
+    // HACK: The Edge browser doesn't render graphs in overlays until a 'resize' event occurs.
+    //       This seems like a flexbox-related bug in Edge. It doesn't occur in any other browser.
+    setTimeout(() => {
+      this.$window.dispatchEvent(new Event('resize'));
+    });
   }
 
   get selectedTimeFilterId() {


### PR DESCRIPTION
I used a bit of a hack to fix this. Since the problem was only occurring in Edge it seemed totally possible that it's just some sort of a bug in Edge. So it didn't seem like it was worth spending hours trying to find a "proper" fix since this seems to work just fine.

## Before
![Before](https://camo.githubusercontent.com/7bb359a8de1f1be537813008bbfeda65c0192bb6/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563336661316662323030623636353463316161393734322f33633233393162362d303861632d346431332d386339302d386536333033616464396338)

## After
![Capture](https://user-images.githubusercontent.com/3220897/64574956-5cc2d080-d326-11e9-8f97-75341e2b0b7f.PNG)