### PR TITLE
Change response and incident map defaults to department lat/lon

### DIFF
--- a/server/fixtures/templates/visualization/incident-map.json
+++ b/server/fixtures/templates/visualization/incident-map.json
@@ -7,6 +7,7 @@
     "visualization": {
       "title": "Incident Map",
       "visState": "{\"title\":\"Map\",\"type\":\"tile_map\",\"params\":{\"mapType\":\"Scaled Circle Markers\",\"isDesaturated\":true,\"addTooltip\":true,\"heatMaxZoom\":\"18\",\"heatMinOpacity\":\"0.86\",\"heatRadius\":\"20\",\"heatBlur\":15,\"heatNormalizeData\":true,\"mapZoom\":2,\"mapCenter\":[15,5],\"wms\":{\"enabled\":false,\"url\":\"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\",\"options\":{\"version\":\"1.3.0\",\"layers\":\"0\",\"format\":\"image/png\",\"transparent\":true,\"attribution\":\"Maps provided by USGS\",\"styles\":\"\"}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"geohash_grid\",\"schema\":\"segment\",\"params\":{\"field\":\"address.geohash\",\"autoPrecision\":true}}],\"listeners\":{}}",
+      "uiStateJSON": "{\"mapZoom\":12,\"mapCenter\":[{{ fire_department.latitude }}, {{ fire_department.longitude }}]}",
       "description": "",
       "version": 1,
       "kibanaSavedObjectMeta": {

--- a/server/fixtures/templates/visualization/response-map.json
+++ b/server/fixtures/templates/visualization/response-map.json
@@ -7,6 +7,7 @@
     "visualization": {
       "title": "Response Map",
       "visState": "{\"title\":\"Response Map\",\"type\":\"tile_map\",\"params\":{\"mapType\":\"Scaled Circle Markers\",\"isDesaturated\":true,\"addTooltip\":true,\"heatMaxZoom\":0,\"heatMinOpacity\":0.1,\"heatRadius\":25,\"heatBlur\":15,\"legendPosition\":\"bottomright\",\"mapZoom\":2,\"mapCenter\":[0,0],\"wms\":{\"enabled\":false,\"url\":\"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\",\"options\":{\"version\":\"1.3.0\",\"layers\":\"0\",\"format\":\"image/png\",\"transparent\":true,\"attribution\":\"Maps provided by USGS\",\"styles\":\"\"}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"geohash_grid\",\"schema\":\"segment\",\"params\":{\"field\":\"address.geohash\",\"autoPrecision\":true,\"useGeocentroid\":true,\"precision\":2}}],\"listeners\":{}}",
+      "uiStateJSON": "{\"mapZoom\":12,\"mapCenter\":[{{ fire_department.latitude }}, {{ fire_department.longitude }}]}",
       "description": "",
       "version": 1,
       "kibanaSavedObjectMeta": {


### PR DESCRIPTION
This will cause those maps to automatically default to the department centroid at a zoom level of 12 when the dashboard is first instantiated.