### PR TITLE
Fix element truncation in app extension list.

### DIFF
--- a/client/app/marketplace/marketplace-home/marketplace-home.scss
+++ b/client/app/marketplace/marketplace-home/marketplace-home.scss
@@ -98,19 +98,15 @@
   			overflow: hidden;
       }
     }
-    .featured-extensions {
+    .featured-extensions,
+    .extensions {
       .col {
-        min-width: 50%;
-        max-width: 50%;
+        width: 100%;
+        max-width: 100%;
+        flex-basis: 100%;
         margin-bottom: 1.5rem;
-        @include media-breakpoint-down(lg) {
-          min-width: 100%;
-          width: 100%;
-        }
       }
       a.card{
-        background-color: #f6f8fa;
-        border-color: #d5dbe3;
         width: 100%;
         height: 125px;
 
@@ -120,26 +116,6 @@
           display: -webkit-box;
           -webkit-line-clamp: 3;
           overflow: hidden;
-        }
-      }
-    }
-    .extensions {
-      .col {
-        min-width: 50%;
-        max-width: 50%;
-        margin-bottom: 1.5rem;
-        @include media-breakpoint-down(lg) {
-          min-width: 100%;
-          width: 100%;
-       }
-      }
-      a.card {
-        width: 100%;
-        height: 125px;
-
-        @include media-breakpoint-down(lg) {
-          max-width: 100%;
-         width: 100%;
         }
       }
     }


### PR DESCRIPTION
I just forced each app extension in the list to take up an entire row. Since the page content has a max width now, they never get too ridiculously wide, and this way we've got a bit more space to play with for titles and descriptions.

I also noticed that the featured extension cards and regular extension cards had nearly identical styles, with very subtle differences. So I went ahead and merged their css together.

## Before
<img width="443" alt="Screen Shot 2019-10-11 at 2 03 31 PM" src="https://user-images.githubusercontent.com/3220897/66684939-0d770500-ec30-11e9-9d64-7b3908bb558b.png">

## After
<img width="442" alt="Screen Shot 2019-10-11 at 2 04 25 PM" src="https://user-images.githubusercontent.com/3220897/66684943-1071f580-ec30-11e9-812c-2a75d45adc3a.png">
