### PR TITLE
Case-insensitive unique email validation.

### DIFF
--- a/server/api/user/user.model.js
+++ b/server/api/user/user.model.js
@@ -41,9 +41,6 @@ export default function(sequelize, DataTypes) {
     email: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: {
-        msg: 'The specified email address is already in use.'
-      },
       validate: {
         isEmail: true
       }
@@ -90,6 +87,22 @@ export default function(sequelize, DataTypes) {
       type: DataTypes.STRING,
     },
   }, {
+    validate: {
+      async validateEmail() {
+        // Sequelize's unique constraint is case-sensitive, so we need to do a manual
+        // case-insensitive check for an existing email here.
+        const user = await User.find({
+          where: sequelize.where(
+            sequelize.fn('LOWER', sequelize.col('email')),
+            this.email.toLowerCase(),
+          ),
+        });
+
+        if(user) {
+          throw new Error(`The specified email address is already in use.`);
+        }
+      },
+    },
 
     /**
      * Virtual Getters

--- a/server/api/user/user.model.js
+++ b/server/api/user/user.model.js
@@ -87,13 +87,19 @@ export default function(sequelize, DataTypes) {
       type: DataTypes.STRING,
     },
   }, {
+    indexes: [{
+      unique: true,
+      name: 'users_email_lower',
+      fields: [sequelize.fn('lower', sequelize.col('email'))],
+    }],
+
     validate: {
       async validateEmail() {
         // Sequelize's unique constraint is case-sensitive, so we need to do a manual
         // case-insensitive check for an existing email here.
         const user = await User.find({
           where: sequelize.where(
-            sequelize.fn('LOWER', sequelize.col('email')),
+            sequelize.fn('lower', sequelize.col('email')),
             this.email.toLowerCase(),
           ),
         });

--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+import 'babel-polyfill';
 import express from 'express';
 import http from 'http';
 


### PR DESCRIPTION
Attempting to sign up using the same email with different casing should now fail.

I added the `babel-polyfill` import to `app.js` so that using `async/await` doesn't throw a regenerator runtime error.