### PR TITLE
Add spread operator support.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,6 +14,7 @@
    ],
     "plugins": [
       "transform-class-properties",
+      "transform-object-rest-spread",
       "angularjs-annotate",
       "syntax-dynamic-import"
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2441,6 +2441,12 @@
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
@@ -2766,6 +2772,16 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
       "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
       "dev": true
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      }
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.9.4",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "babel-plugin-angularjs-annotate": "^0.8.2",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.6.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.6.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
This has just been annoying me slightly for a while to not be able to use the spread operator, so I thought I'd go ahead and add support for it.

Now we can do things like this without getting errors...

```js
const a = { 'a': 1 };
const b = { 'b': 2, ...a };
```