### PR TITLE
add github templates to the project

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at joe.chop@prominentedge.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Use this to report bugs
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+**Description:**
+
+
+**Expected Behavior**
+
+-
+
+**Environment**
+
+-
+
+**Steps to reproduce**
+
+-
+-

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,24 +1,19 @@
 ---
-name: Bug report
+name: Bug Report
 about: Use this to report bugs
 title: "[BUG] "
 labels: bug
 assignees: ''
-
 ---
 
-**Description:**
+## Overview
 
 
-**Expected Behavior**
+## Expected Behavior
 
+
+## Environment
 -
 
-**Environment**
-
--
-
-**Steps to reproduce**
-
--
+## Steps to Reproduce
 -

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,22 +1,15 @@
 ---
-name: Feature request
+name: Feature Request
 about: Use this to request new features
 title: ""
 labels: ''
 assignees: ''
 ---
 
-## Prelude
-Preliminary history of the issue. Share any information that could ease the understanding of why this issue exists. Try to line up the major concerns that might affect the project until this issue is not implemented.
+## Overview
 
-## BDD Scenarios
-[ ] Scenario 1:
-GIVEN ...
-WHEN ...
-THEN ..
 
-[ ] Scenario 2:
-GIVEN ...
-WHEN ...
-THEN ...
- 
+## Acceptance Criterias
+-
+
+## Mockups / Screenshots

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Use this to request new features
+title: ""
+labels: ''
+assignees: ''
+---
+
+## Prelude
+Preliminary history of the issue. Share any information that could ease the understanding of why this issue exists. Try to line up the major concerns that might affect the project until this issue is not implemented.
+
+## BDD Scenarios
+[ ] Scenario 1:
+GIVEN ...
+WHEN ...
+THEN ..
+
+[ ] Scenario 2:
+GIVEN ...
+WHEN ...
+THEN ...
+ 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ assignees: ''
 ## Overview
 
 
-## Acceptance Criterias
+## Acceptance Criteria
 -
 
 ## Mockups / Screenshots

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,14 @@
-## Prelude
-Preliminary history of the issue related to this very Pull Request. Share any information that could ease the understanding of why this issue exists and what measures have been administered to address it.
+## Overview
 
-## Issue
-[Link the GitHub issue here]
 
-## List of changes
-- 
-- 
+## GitHub Issues
 -
 
-## Screenshots, gifs, videos
-[copy assets here]
-
-## Test scenarios
-- 
+## Changes
 -
+
+## Screenshots / Videos
+
+
+## Steps to Test
 -

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Prelude
+Preliminary history of the issue related to this very Pull Request. Share any information that could ease the understanding of why this issue exists and what measures have been administered to address it.
+
+## Issue
+[Link the GitHub issue here]
+
+## List of changes
+- 
+- 
+-
+
+## Screenshots, gifs, videos
+[copy assets here]
+
+## Test scenarios
+- 
+-
+-


### PR DESCRIPTION
## Prelude
Issue and Pull Request templates should be introduced to the project in order to help maintain consistency in defining features and bugs.

## Issues
- #382 

## Screenshots

## Notes
Please add or remove lines from the proposed templates if need be.