### PR TITLE
Add makefile to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,4 @@ dist
 npm-debug.log
 coverage
 *.sqlite
-Makefile
 env.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Makefile for building stat-engine
+
+ORG ?= prominentedgestatengine
+REPO ?= statengine
+ENVIRONMENT ?= development
+
+SHA=$(shell git rev-parse --short HEAD)
+BRANCH=$(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+
+TAG=${BRANCH}-${SHA}-${ENVIRONMENT}
+NOW=$(shell date -u +%FT%TZ)
+
+build:
+	docker build \
+	-t $(ORG)/$(REPO):${TAG} \
+	--build-arg MAPBOX_TOKEN=${MAPBOX_TOKEN} \
+	--build-arg AMPLITUDE_API_KEY=${AMPLITUDE_API_KEY} \
+	--build-arg BUILD_VERSION=${TAG} \
+  --build-arg BUILD_DATE=${NOW} \
+	--network=host \
+	--no-cache \
+	.
+	echo "TAG=${TAG}" > tag.properties
+
+push:
+	docker push \
+	$(ORG)/$(REPO):${TAG}


### PR DESCRIPTION
We used to store our makefiles in a separate devops repo, but due to some changes in the way we run the build jobs, we need to keep the Makefiles with the application code.  It also makes more sense to me to keep the Makefile in this repo.  