### PR TITLE
Change "Dashboard" menu items to "Workspaces".

### DIFF
--- a/client/app/user/user-home/user-home.html
+++ b/client/app/user/user-home/user-home.html
@@ -50,9 +50,9 @@
           </div>
         </div>
         <div class="col-lg actions mg-t-5" ng-if="vm.appAccess">
-          <a href="" ng-click="vm.goto('site.workspace.home','Dashboard')">
+          <a href="" ng-click="vm.goto('site.workspace.home', 'Workspaces')">
             <img src="/assets/images/actions-dashboard.svg"/>
-            <span>Dashboard</span>
+            <span>Workspaces</span>
           </a>
           <a ng-if="!vm.appConfig.on_premise" href="" ng-click="vm.goto('site.twitter.home','Twitter')">
             <img src="/assets/images/actions-twitter.svg"/>

--- a/client/components/navbar/navbar.component.js
+++ b/client/components/navbar/navbar.component.js
@@ -34,19 +34,11 @@ export class NavbarComponent {
       $('.app-content-view').animate({ scrollTop: $(location).offset().top }, 1000);
     };
 
-    this.dashboard = function(location) {
-      this.AmplitudeService.track(this.AnalyticEventNames.APP_ACCESS, {
-        app: 'Dashboard',
-        location
-      });
-      this.$window.location.href = '/workspace';
-    };
-
-    this.goto = (state, appName) => {
+    this.goto = (state, appName, location = 'navbar-dropdown') => {
       if(appName) {
         this.AmplitudeService.track(this.AnalyticEventNames.APP_ACCESS, {
           app: appName,
-          location: 'navbar-dropdown'
+          location,
         });
       }
       $state.go(state);

--- a/client/components/navbar/navbar.html
+++ b/client/components/navbar/navbar.html
@@ -46,7 +46,7 @@
            <li ng-if="vm.currentPrincipal.fire_department__id" class="with-dropdown"> <a class="" href="#" ng-click="vm.openDropdown('apps')">Apps</a>
              <div class="dropdown animated fadeInDownShort" ng-class="{'open': vm.openDropdowns['apps']}">
                <ul>
-                 <li><a href="#" ng-click="vm.dashboard('navbar-dropdown')">Dashboard</a></li>
+                 <li><a href="#" ng-click="vm.goto('site.workspace.home', 'Workspaces')">Workspaces</a></li>
                  <li ng-if="!vm.appConfig.on_premise"><a href="#" ng-click="vm.goto('site.twitter.home','Twitter')">Twitter</a></li>
                  <li ng-if="!vm.appConfig.on_premise"><a href="#" ng-click="vm.goto('site.report.today','Reporting')">Reporting</a></li>
                  <li><a href="#" ng-click="vm.goto('site.incident.search','Incident Analysis')">Incident Analysis</a></li>
@@ -74,7 +74,7 @@
       <!-- Authenticated -->
       <div ng-if="vm.PrincipalService.isAuthenticated()">
         <ul class="secondary-nav">
-          <li><a href="" ng-click="vm.dashboard('navbar-icon')" class="se-icon-dashboard"></a></li>
+          <li><a href="" ng-click="vm.goto('site.workspace.home', 'Workspaces', 'navbar-icon')" class="se-icon-dashboard"></a></li>
           <li><a href="https://statengine.github.io/se-documentation/" target="_blank" class="se-icon-help"></a></li>
           <li class="with-dropdown"><a href="" ng-click="vm.openDropdown('user')" class="se-icon-user"></a>
             <div class="settings dropdown animated fadeInDownShort" ng-class="{'open': vm.openDropdowns['user']}">
@@ -106,7 +106,7 @@
 
         <ul ng-if="vm.PrincipalService.isAuthenticated()">
           <li><a href="site.user.home">Control Center</a></li>
-          <li><a href="#" ng-click="vm.dashboard('navbar-dropdown')">Dashboard</a></li>
+          <li><a href="#" ng-click="vm.goto('site.workspace.home', 'Workspaces')">Workspaces</a></li>
           <li ng-if="!vm.appConfig.on_premise"><a href="#" ng-click="vm.goto('site.twitter.home','Twitter')">Twitter</a></li>
           <li ng-if="!vm.appConfig.on_premise"><a href="#" ng-click="vm.goto('site.report.today','Reporting')">Reporting</a></li>
           <li><a href="#" ng-click="vm.goto('site.incident.search','Incident Analysis')">Incident Analysis</a></li>

--- a/client/components/sidebar/sidebar.component.js
+++ b/client/components/sidebar/sidebar.component.js
@@ -35,7 +35,7 @@ export class SidebarComponent {
 
   dashboard() {
     this.AmplitudeService.track(this.AnalyticEventNames.APP_ACCESS, {
-      app: 'Dashboard',
+      app: 'Workspaces',
       location: 'sidebar',
     });
     this.$state.go('site.workspace.home');

--- a/client/components/sidebar/sidebar.html
+++ b/client/components/sidebar/sidebar.html
@@ -23,8 +23,8 @@
         </li>
         <li class="br-menu-item" ng-show="vm.user.fire_department__id">
           <a href="#" ng-class="{ active: vm.$state.current.name == 'site.workspace.home' }" ng-click='vm.dashboard()' class="br-menu-link">
-            <i class="menu-item-icon fa fa-dashboard tx-20"></i>
-            <span class="menu-item-label text-truncate">Dashboard</span>
+            <i class="menu-item-icon fa fa-bar-chart tx-20"></i>
+            <span class="menu-item-label text-truncate">Workspaces</span>
           </a>
         </li>
         <li class="br-menu-item" ng-show="vm.user.fire_department__id">


### PR DESCRIPTION
All "Dashboard" items should now say "Workspaces".

I also changed "Dashboard" to "Workspaces" in all of the Amplitude events, to avoid confusion. I guess that'll probably break tracking consistency for a little bit though... let me know if you don't think that change is worth it.

I also updated the sidebar icon, changing it from the dial to a bar chart in order to be more consistent with the action icon in the control center. I think it looks a little better than the dial as well.

<img width="258" alt="Screen Shot 2019-10-25 at 6 56 04 PM" src="https://user-images.githubusercontent.com/3220897/67612697-8f4f4e00-f759-11e9-9d3c-b2593a2602a8.png">
<img width="123" alt="Screen Shot 2019-10-25 at 6 56 19 PM" src="https://user-images.githubusercontent.com/3220897/67612699-937b6b80-f759-11e9-8ec3-114152102713.png">
