### PR TITLE
Quints are engines

### DIFF
--- a/server/api/incident/incident.js
+++ b/server/api/incident/incident.js
@@ -50,10 +50,6 @@ export class Incident {
     return _.get(this.incident, 'durations');
   }
 
-  get NFPA() {
-    return _.get(this.incident, 'NFPA');
-  }
-
   get weather() {
     return _.get(this.incident, 'weather');
   }
@@ -166,15 +162,16 @@ export class Incident {
   }
 
   get alarmProcessingDurationSeconds() {
-    return _.get(this.incident, 'NFPA.alarm_processing_duration_seconds');
+    return _.get(this.incident, 'durations.alarm_processing.seconds');
   }
 
   get alarmAnsweringDurationSeconds() {
-    return _.get(this.incident, 'NFPA.alarm_answering_duration_seconds');
+    return _.get(this.incident, 'durations.alarm_answering_duration_seconds');
   }
 
   get firstEngineTravelSeconds() {
-    return _.get(this.incident, 'NFPA.first_engine_travel_duration_seconds');
+    console.dir(this.firstEngineUnitArrived)
+    return this.firstEngineUnitArrived ? _.get(this.firstEngineUnitArrived, 'extended_data.travel_duration')  : undefined;
   }
 
   get travelMatrix() {

--- a/server/api/incident/incident.js
+++ b/server/api/incident/incident.js
@@ -170,8 +170,7 @@ export class Incident {
   }
 
   get firstEngineTravelSeconds() {
-    console.dir(this.firstEngineUnitArrived)
-    return this.firstEngineUnitArrived ? _.get(this.firstEngineUnitArrived, 'extended_data.travel_duration')  : undefined;
+    return this.firstEngineUnitArrived ? _.get(this.firstEngineUnitArrived, 'extended_data.travel_duration') : undefined;
   }
 
   get travelMatrix() {

--- a/server/api/incident/incident.js
+++ b/server/api/incident/incident.js
@@ -166,7 +166,7 @@ export class Incident {
   }
 
   get alarmAnsweringDurationSeconds() {
-    return _.get(this.incident, 'durations.alarm_answering_duration_seconds');
+    return _.get(this.incident, 'durations.alarm_answering.seconds');
   }
 
   get firstEngineTravelSeconds() {

--- a/server/api/incident/incident.js
+++ b/server/api/incident/incident.js
@@ -166,7 +166,7 @@ export class Incident {
   }
 
   get alarmAnsweringDurationSeconds() {
-    return _.get(this.incident, 'durations.alarm_answering.seconds');
+    return _.get(this.incident, 'durations.alarm_answer.seconds');
   }
 
   get firstEngineTravelSeconds() {


### PR DESCRIPTION
## Overview

NFPA engine travel times should include quints and ladders, which also provide suppression capabilities.  

## GitHub Issues
Customer reported

## Changes
The NFPA fields are phased for deprecation, so I updated the field references.  

## Screenshots / Videos
N/A

## Steps to Test
Navigate to: http://localhost:3000/incidents/F01812310077.
![image](https://user-images.githubusercontent.com/32108478/67729542-96fb3680-f995-11e9-907b-de9f27e5c215.png)

First engine travel time should reflect E14s travel time
