### PR TITLE
change heartbeat endpoint to GET

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -11,6 +11,12 @@ import errors from './components/errors';
 import config from './config/environment';
 
 export default function(app) {
+  // Kubernetes uses this route to ensure the servie is up
+  app.route('/heartbeat')
+  .get((res, req) => {
+    req.status(204).send();
+  });
+
   // Insert API routes below
   app.use('/api/app', require('./api/app'));
   app.use('/api/apps', require('./api/apps'));
@@ -39,11 +45,6 @@ export default function(app) {
   app.use(lusca.csrf({
     angular: true,
   }));
-
-  app.route('/heartbeat')
-    .post((res, req) => {
-      req.status(204).send();
-    });
 
   // Authentication
   app.use('/auth', require('./auth').default);

--- a/server/routes.js
+++ b/server/routes.js
@@ -11,7 +11,7 @@ import errors from './components/errors';
 import config from './config/environment';
 
 export default function(app) {
-  // Kubernetes uses this route to ensure the servie is up
+  // Kubernetes uses this route to ensure the service is up
   app.route('/heartbeat')
   .get((res, req) => {
     req.status(204).send();


### PR DESCRIPTION
## Overview

K8S needs a GET endpoint to check for readiness.  

## GitHub Issues
none

## Changes
- Changed POST heartbeat endpoint to a GET 

## Screenshots / Videos
none

## Steps to Test
- GET localhost:3000/heartbeat returns 204
