### PR TITLE
Fix incidents analysis white page on first load.

### DIFF
--- a/client/app/incident/incident-analysis/incident-analysis.controller.js
+++ b/client/app/incident/incident-analysis/incident-analysis.controller.js
@@ -26,7 +26,11 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
 
 export default class IncidentAnalysisController {
   /*@ngInject*/
-  constructor($scope, AmplitudeService, AnalyticEventNames, currentPrincipal, incidentData, Print) {
+  constructor($scope, AmplitudeService, AnalyticEventNames, currentPrincipal, incidentData, Print, modules) {
+    _ = modules._;
+    tippy = modules.tippy;
+    PlotlyBasic = modules.PlotlyBasic;
+
     this.$scope = $scope;
     this.AmplitudeService = AmplitudeService;
     this.AnalyticEventNames = AnalyticEventNames;
@@ -35,16 +39,7 @@ export default class IncidentAnalysisController {
     this.Print = Print;
   }
 
-  async loadModules() {
-    _ = await import(/* webpackChunkName: "lodash" */ 'lodash');
-    tippy = await import(/* webpackChunkName: "tippy" */ 'tippy.js');
-    tippy = tippy.default;
-    PlotlyBasic = await import(/* webpackChunkName: "plotly-basic" */ 'plotly.js/dist/plotly-basic.js');
-  }
-
-  async $onInit() {
-    await this.loadModules();
-
+  $onInit() {
     this.groupedUnits = _.groupBy(this.incidentData.incident.apparatus, u => u.suppressed);
 
     this.suppressedUnits = this.groupedUnits.true;
@@ -123,7 +118,6 @@ export default class IncidentAnalysisController {
 
     this.formatSearchResults(this.concurrentIncidents);
 
-    this.initialized = true;
     this.initTippy();
 
     this.Print.addBeforePrintListener(this.beforePrint);

--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -1,4 +1,4 @@
-<section class="incident-analysis" ng-if="vm.initialized">
+<section class="incident-analysis">
   <div class="br-pageheader">
     <nav class="breadcrumb">
       <a class="breadcrumb-item" href="index.html">Home</a>

--- a/client/app/incident/incident.routes.js
+++ b/client/app/incident/incident.routes.js
@@ -49,6 +49,13 @@ export default function routes($stateProvider) {
             import(/* webpackChunkName: "ui-grid" */ 'angular-ui-grid/ui-grid').then(() => $ocLazyLoad.inject('ui.grid')),
           ]);
         },
+        async modules() {
+          const modules = {};
+          modules._ = await import(/* webpackChunkName: "lodash" */ 'lodash');
+          modules.tippy = (await import(/* webpackChunkName: "tippy" */ 'tippy.js')).default;
+          modules.PlotlyBasic = await import(/* webpackChunkName: "plotly-basic" */ 'plotly.js/dist/plotly-basic.js');
+          return modules;
+        },
         currentPrincipal(Principal) {
           return Principal.identity();
         },


### PR DESCRIPTION
## Overview
The Incidents Analysis page was essentially timing out during initialization, since it was using `async $onInit()` which doesn't seem to be properly supported by AngularJS. So Angular was ignoring the fact that `vm.initialized` had been set to true and not rendering the page.

## GitHub Issues
- #398 

## Changes
- Moved module lazy loading to Incident Analysis page route resolvers.
- Removed `ng-if="vm.initialized"` from root element in Incident Analysis page.

## Steps to Test
- In `master` branch, add the following code to the start of `$onInit()` in `incident.analysis.controller.js`:
```js
await new Promise(resolve => {
  setTimeout(resolve, 3000);
});
```
- With caching disabled, navigate to the Incident Analysis page. It should show a blank white page even after the 3 seconds have passed.
- In `fix-incident-white-page` branch, add the same timeout code block, but put it in `async modules()` in the `site.incident.analysis` resolvers.
- With caching disabled, navigate to the Incident Analysis page. It should load properly after the 3 seconds have passed.
