### PR TITLE
Only validate user email on create.

### DIFF
--- a/server/api/user/user.model.js
+++ b/server/api/user/user.model.js
@@ -95,17 +95,19 @@ export default function(sequelize, DataTypes) {
 
     validate: {
       async validateEmail() {
-        // Sequelize's unique constraint is case-sensitive, so we need to do a manual
-        // case-insensitive check for an existing email here.
-        const user = await User.find({
-          where: sequelize.where(
-            sequelize.fn('lower', sequelize.col('email')),
-            this.email.toLowerCase(),
-          ),
-        });
+        if(this.isNewRecord) {
+          // Sequelize's unique constraint is case-sensitive, so we need to do a manual
+          // case-insensitive check for an existing email here.
+          const user = await User.find({
+            where: sequelize.where(
+              sequelize.fn('lower', sequelize.col('email')),
+              this.email.toLowerCase(),
+            ),
+          });
 
-        if(user) {
-          throw new Error(`The specified email address is already in use.`);
+          if(user) {
+            throw new Error(`The specified email address is already in use.`);
+          }
         }
       },
     },


### PR DESCRIPTION
## Overview
User email should only be validated when the account is being created.

## GitHub Issues
- #407 

## Changes
- Guarded user email validation with check against sequelize's `this.isNewRecord` field

## Steps to Test
- Create new user account
- Login as department admin for the new user's requested department
- Approve user
- User should be approved with no errors
