### PR TITLE
add filter inputs to incidents

### DIFF
--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -27,8 +27,7 @@ export default class IncidentSearchController {
   uiGridColumnDefs;
 
   /*@ngInject*/
-  constructor($window, $scope, AmplitudeService, AnalyticEventNames, Incident, currentPrincipal) {
-    this.$scope = $scope;
+  constructor($window, AmplitudeService, AnalyticEventNames, Incident, currentPrincipal) {
     this.$window = $window;
     this.IncidentService = Incident;
     this.AmplitudeService = AmplitudeService;
@@ -92,8 +91,8 @@ export default class IncidentSearchController {
       from: (this.pagination.page - 1) * this.pagination.pageSize,
       sort,
       search: this.search,
-      eventOpened: this.rangeFromDateTz,
-      eventClosed: this.rangeToDateTz,
+      fromDate: this.rangeFromDateTz,
+      toDate: this.rangeToDateTz,
     }).$promise;
 
     this.incidents = data.items.map(item => item._source);
@@ -137,14 +136,16 @@ export default class IncidentSearchController {
   }
 
   initRangeFilter() {
-    this.$scope.fromDatePopup = { opened: false };
-    this.$scope.openFromDatePopup = () => {
-      this.$scope.fromDatePopup.opened = true;
-    };
-    this.$scope.toDatePopup = { opened: false };
-    this.$scope.openToDatePopup = () => {
-      this.$scope.toDatePopup.opened = true;
-    };
+    this.fromDatePopupOpened = false;
+    this.toDatePopupOpened = false;
+  }
+
+  openFromDatePopup() {
+    this.fromDatePopupOpened = true;
+  }
+
+  openToDatePopup() {
+    this.toDatePopupOpened = true;
   }
 
   getRangeDate(time, date) {
@@ -155,33 +156,32 @@ export default class IncidentSearchController {
   }
 
   onDateRangeChanged() {
-    const { fromDate, fromTime, toDate,toTime } = this.$scope;
     const { timezone } = this.fireDepartment;
-    const rangeFromDate = this.getRangeDate(fromTime, fromDate);
-    const rangeToDate = this.getRangeDate(toTime, toDate);
+    const rangeFromDate = this.getRangeDate(this.fromTime, this.fromDate);
+    const rangeToDate = this.getRangeDate(this.toTime, this.toDate);
 
     if (rangeFromDate) {
-      this.rangeFromDateTz = new Date(moment.tz(rangeFromDate, timezone).format());
+      this.rangeFromDateTz = moment(rangeFromDate).tz(timezone, true).format();
     }
 
     if (rangeToDate) {
-      this.rangeToDateTz = new Date(moment.tz(rangeToDate, timezone).format());
+      this.rangeToDateTz = moment(rangeToDate).tz(timezone, true).format();
     }
 
     this.refreshIncidentsList();
   }
 
   clearFromDate() {
-    this.$scope.fromDate = undefined;
-    this.$scope.fromTime = undefined;
+    this.fromDate = undefined;
+    this.fromTime = undefined;
     this.rangeFromDateTz = undefined;
     this.refreshIncidentsList();
   }
 
   clearToDate() {
-    this.$scope.toDate = undefined;
-    this.$scope.toTime = undefined;
+    this.toDate = undefined;
+    this.toTime = undefined;
     this.rangeToDateTz = undefined;
-
+    this.refreshIncidentsList();
   }
 }

--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -92,19 +92,11 @@ export default class IncidentSearchController {
       from: (this.pagination.page - 1) * this.pagination.pageSize,
       sort,
       search: this.search,
+      eventOpened: this.rangeFromDateTz,
+      eventClosed: this.rangeToDateTz,
     }).$promise;
+
     this.incidents = data.items.map(item => item._source);
-
-    this.incidents = this.incidents.filter(incident => {
-      const dateClosed = new Date(incident.description.event_closed);
-      if (this.rangeFromDateTz && dateClosed.getTime() < this.rangeFromDateTz.getTime()) {
-        return false;
-      } else if (this.rangeToDateTz && dateClosed.getTime() > this.rangeToDateTz.getTime()) {
-        return false;
-      }
-      return true;
-    });
-
     this.pagination.totalItems = data.totalItems;
 
     // HACK: Compute 'unitCount' from 'units' (this should be preprocessed in the database).
@@ -165,17 +157,31 @@ export default class IncidentSearchController {
   onDateRangeChanged() {
     const { fromDate, fromTime, toDate,toTime } = this.$scope;
     const { timezone } = this.fireDepartment;
-    this.rangeFromDate = this.getRangeDate(fromTime, fromDate);
-    this.rangeToDate = this.getRangeDate(toTime, toDate);
+    const rangeFromDate = this.getRangeDate(fromTime, fromDate);
+    const rangeToDate = this.getRangeDate(toTime, toDate);
 
-    if (this.rangeFromDate) {
-      this.rangeFromDateTz = new Date(moment.tz(this.rangeFromDate, timezone).format());
+    if (rangeFromDate) {
+      this.rangeFromDateTz = new Date(moment.tz(rangeFromDate, timezone).format());
     }
 
-    if (this.rangeToDate) {
-      this.rangeToDateTz = new Date(moment.tz(this.rangeToDate, timezone).format());
+    if (rangeToDate) {
+      this.rangeToDateTz = new Date(moment.tz(rangeToDate, timezone).format());
     }
 
     this.refreshIncidentsList();
+  }
+
+  clearFromDate() {
+    this.$scope.fromDate = undefined;
+    this.$scope.fromTime = undefined;
+    this.rangeFromDateTz = undefined;
+    this.refreshIncidentsList();
+  }
+
+  clearToDate() {
+    this.$scope.toDate = undefined;
+    this.$scope.toTime = undefined;
+    this.rangeToDateTz = undefined;
+
   }
 }

--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -27,12 +27,13 @@ export default class IncidentSearchController {
   uiGridColumnDefs;
 
   /*@ngInject*/
-  constructor($window, AmplitudeService, AnalyticEventNames, Incident, currentPrincipal) {
+  constructor($window, AmplitudeService, AnalyticEventNames, Incident, currentPrincipal, Modal) {
     this.$window = $window;
     this.IncidentService = Incident;
     this.AmplitudeService = AmplitudeService;
     this.AnalyticEventNames = AnalyticEventNames;
     this.fireDepartment = currentPrincipal.FireDepartment;
+    this.Modal = Modal;
 
     this.uiGridColumnDefs = [{
       field: 'description.incident_number',
@@ -91,8 +92,8 @@ export default class IncidentSearchController {
       from: (this.pagination.page - 1) * this.pagination.pageSize,
       sort,
       search: this.search,
-      fromDate: this.rangeFromDateTz,
-      toDate: this.rangeToDateTz,
+      fromDate: this.rangeFromDateTz && this.rangeFromDateTz.format(),
+      toDate: this.rangeToDateTz && this.rangeToDateTz.format(),
     }).$promise;
 
     this.incidents = data.items.map(item => item._source);
@@ -156,19 +157,39 @@ export default class IncidentSearchController {
   }
 
   onDateRangeChanged() {
+    this.updateDateRange();
+    if (this.checkIfDateRangeValid()) {
+      this.refreshIncidentsList();
+    }
+  }
+
+  updateDateRange() {
     const { timezone } = this.fireDepartment;
     const rangeFromDate = this.getRangeDate(this.fromTime, this.fromDate);
     const rangeToDate = this.getRangeDate(this.toTime, this.toDate);
 
     if (rangeFromDate) {
-      this.rangeFromDateTz = moment(rangeFromDate).tz(timezone, true).format();
+      this.rangeFromDateTz = moment(rangeFromDate).tz(timezone, true);
     }
 
     if (rangeToDate) {
-      this.rangeToDateTz = moment(rangeToDate).tz(timezone, true).format();
+      this.rangeToDateTz = moment(rangeToDate).tz(timezone, true);
     }
+  }
 
-    this.refreshIncidentsList();
+  checkIfDateRangeValid() {
+    if (!this.rangeToDateTz || !this.rangeFromDateTz) return true;
+    if (this.rangeFromDateTz.unix() < this.rangeToDateTz.unix()) return true;
+    this.Modal.custom({
+      title: 'Invalid Date Range',
+      content: "The first date of the time range cannot be later than the second date!",
+      buttons: [{
+        text: 'Ok',
+        style: this.Modal.buttonStyle.primary,
+        onClick: () => this.clearFromDate(),
+      }],
+    }).present();
+    return false;
   }
 
   clearFromDate() {

--- a/client/app/incident/incident-search/incident-search.html
+++ b/client/app/incident/incident-search/incident-search.html
@@ -35,12 +35,12 @@
           <span>From:</span>
         </div>
         <div class="input-group wd-180">
-          <input type="text" ng-change="vm.onDateRangeChanged()" class="form-control" uib-datepicker-popup ng-model="fromDate" is-open="fromDatePopup.opened" close-text="Close" />
+          <input type="text" ng-change="vm.onDateRangeChanged()" class="form-control" uib-datepicker-popup ng-model="vm.fromDate" is-open="vm.fromDatePopupOpened" close-text="Close" />
           <span class="input-group-btn">
-            <button type="button" class="btn btn-default" ng-click="openFromDatePopup()"><i class="fa fa-calendar"></i></button>
+            <button type="button" class="btn btn-default" ng-click="vm.openFromDatePopup()"><i class="fa fa-calendar"></i></button>
           </span>
         </div>
-        <div class="input-group wd-150" uib-timepicker ng-model="fromTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>
+        <div class="input-group wd-150" uib-timepicker ng-model="vm.fromTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>
         <div class="input-group wd-50">
           <button type="button" class="btn btn-default" ng-click="vm.clearFromDate();"><i class="fa fa-ban"></i></button>
         </div>
@@ -48,12 +48,12 @@
           <span>To:</span>
         </div>
         <div class="input-group wd-180">
-          <input type="text" ng-change="vm.onDateRangeChanged()" class="form-control" uib-datepicker-popup ng-model="toDate" is-open="toDatePopup.opened" close-text="Close" />
+          <input type="text" ng-change="vm.onDateRangeChanged()" class="form-control" uib-datepicker-popup ng-model="vm.toDate" is-open="vm.toDatePopupOpened" close-text="Close" />
           <span class="input-group-btn">
-            <button type="button" class="btn btn-default" ng-click="openToDatePopup()"><i class="fa fa-calendar"></i></button>
+            <button type="button" class="btn btn-default" ng-click="vm.openToDatePopup()"><i class="fa fa-calendar"></i></button>
           </span>
         </div>
-        <div class="input-group wd-150" uib-timepicker ng-model="toTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>
+        <div class="input-group wd-150" uib-timepicker ng-model="vm.toTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>
         <div class="input-group wd-50">
           <button type="button" class="btn btn-default" ng-click="vm.clearToDate();"><i class="fa fa-ban"></i></button>
         </div>

--- a/client/app/incident/incident-search/incident-search.html
+++ b/client/app/incident/incident-search/incident-search.html
@@ -42,6 +42,9 @@
         </div>
         <div class="input-group wd-150" uib-timepicker ng-model="fromTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>
         <div class="input-group wd-50">
+          <button type="button" class="btn btn-default" ng-click="vm.clearFromDate();"><i class="fa fa-ban"></i></button>
+        </div>
+        <div class="input-group wd-50">
           <span>To:</span>
         </div>
         <div class="input-group wd-180">
@@ -50,7 +53,10 @@
             <button type="button" class="btn btn-default" ng-click="openToDatePopup()"><i class="fa fa-calendar"></i></button>
           </span>
         </div>
-        <div class="input-group wd-150" uib-timepicker ng-model="toTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>        
+        <div class="input-group wd-150" uib-timepicker ng-model="toTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>
+        <div class="input-group wd-50">
+          <button type="button" class="btn btn-default" ng-click="vm.clearToDate();"><i class="fa fa-ban"></i></button>
+        </div>
       </div>
     </setion>
     <section>

--- a/client/app/incident/incident-search/incident-search.html
+++ b/client/app/incident/incident-search/incident-search.html
@@ -28,6 +28,31 @@
     </div>
   </div><!-- br-pagetitle -->
   <div class="br-pagebody">
+    <setion>
+      <h5>Filters</h5>
+      <div class="incident-filters input-group">
+        <div class="input-group wd-50">
+          <span>From:</span>
+        </div>
+        <div class="input-group wd-180">
+          <input type="text" ng-change="vm.onDateRangeChanged()" class="form-control" uib-datepicker-popup ng-model="fromDate" is-open="fromDatePopup.opened" close-text="Close" />
+          <span class="input-group-btn">
+            <button type="button" class="btn btn-default" ng-click="openFromDatePopup()"><i class="fa fa-calendar"></i></button>
+          </span>
+        </div>
+        <div class="input-group wd-150" uib-timepicker ng-model="fromTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>
+        <div class="input-group wd-50">
+          <span>To:</span>
+        </div>
+        <div class="input-group wd-180">
+          <input type="text" ng-change="vm.onDateRangeChanged()" class="form-control" uib-datepicker-popup ng-model="toDate" is-open="toDatePopup.opened" close-text="Close" />
+          <span class="input-group-btn">
+            <button type="button" class="btn btn-default" ng-click="openToDatePopup()"><i class="fa fa-calendar"></i></button>
+          </span>
+        </div>
+        <div class="input-group wd-150" uib-timepicker ng-model="toTime" hour-step="1" minute-step="1" show-meridian="ismeridian" ng-change="vm.onDateRangeChanged()"></div>        
+      </div>
+    </setion>
     <section>
       <incidents-table
         incidents="vm.incidents"

--- a/client/app/incident/incident-search/incident-search.scss
+++ b/client/app/incident/incident-search/incident-search.scss
@@ -19,7 +19,13 @@
 			border: none;
 			padding: 0;
 		}
+
+		input {
+			width: 53px !important;
+		}
 	}
+
+
 
 	.input-group {
 		align-items: center;

--- a/client/app/incident/incident-search/incident-search.scss
+++ b/client/app/incident/incident-search/incident-search.scss
@@ -5,3 +5,24 @@
     }
   }
 }
+
+.incident-filters {
+	.btn {
+		padding: 0.375rem 0.75rem;
+	}
+
+	.uib-timepicker {
+		border: none;
+
+		td {
+			background-color: initial;
+			border: none;
+			padding: 0;
+		}
+	}
+
+	.input-group {
+		align-items: center;
+		justify-content: center;
+	}
+}

--- a/client/app/incident/incident.routes.js
+++ b/client/app/incident/incident.routes.js
@@ -28,6 +28,9 @@ export default function routes($stateProvider) {
               $ocLazyLoad.inject('ui.grid.resizeColumns');
             });
         },
+        currentPrincipal(Principal) {
+          return Principal.identity(true);
+        },
       },
     })
     .state('site.incident.analysis', {

--- a/server/api/incident/incident.controller.js
+++ b/server/api/incident/incident.controller.js
@@ -105,6 +105,8 @@ export async function getSummary(req, res) {
 
 export async function getIncidents(req, res) {
   const sort = req.query.sort || 'description.event_closed,desc';
+  const eventOpened = req.query.eventOpened;
+  const eventClosed = req.query.eventClosed;
 
   const params = {
     index: req.user.FireDepartment.get().es_indices['fire-incident'],
@@ -144,9 +146,29 @@ export async function getIncidents(req, res) {
           term: {
             'description.suppressed': false,
           }
-        }]
+        }],
       }
     };
+
+    if (eventOpened) {
+      params.body.query.bool.must.push({
+        range: {
+          'description.event_opened': {
+            gte: eventOpened,
+          }
+        },
+      });
+    }
+
+    if (eventClosed) {
+      params.body.query.bool.must.push({
+        range: {
+          'description.event_closed': {
+            lte: eventClosed,
+          }
+        },
+      });
+    }
   }
 
   const searchResults = await connection.getClient().search(params);


### PR DESCRIPTION
## Overview
Add two fields to search by, startDate and endDate.

## GitHub Issues
- #404 

## Changes
- Added TimePicker and DatePicker component pairs to form a time range input
- Hooked these components with the corresponding controller in the scope
- Added logic to filter out incidents that occurred outside of the given time window

## Screenshots / Videos
<img width="1181" alt="Screenshot 2019-11-12 at 21 20 47" src="https://user-images.githubusercontent.com/6104164/68775414-b7cab980-062e-11ea-8fd7-8e145b1c2893.png">
<img width="1185" alt="Screenshot 2019-11-12 at 21 24 05" src="https://user-images.githubusercontent.com/6104164/68775416-b8635000-062e-11ea-94b1-dfaa35dd0df8.png">

## Steps to Test
- Go to `incidents/search` page
- Fill up the range components
- Check whether the results are in the given time window

## UX Recommendations
Based on a chat with @bingles a more UX friendly widget may be used where the Time and Date picker inputs are put together in the same popup.

![image](https://user-images.githubusercontent.com/6104164/68776049-ba79de80-062f-11ea-9027-d05e24b020ae.png)


