### PR TITLE
apply auto margin for both sides

### DIFF
--- a/client/components/footer/footer.html
+++ b/client/components/footer/footer.html
@@ -53,7 +53,7 @@
   <section id="bottom-bar">
     <div class="container">
       <div class="row align-items-left">
-        <div class="col-sm-auto ml-auto legal">© Prominent Edge | <a id='footer-terms-of-service' ui-sref="site.main.termsOfUse">Terms &#38; Privacy</a> | Version: {{ vm.buildConfig.version }}</div>
+        <div class="col-sm-auto mr-auto ml-auto legal">© Prominent Edge | <a id='footer-terms-of-service' ui-sref="site.main.termsOfUse">Terms &#38; Privacy</a> | Version: {{ vm.buildConfig.version }}</div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Overview
The copyright section in the Footer should be center-aligned in all resolutions.

## GitHub Issues
- #389 

## Changes
- Applied margin-right on the footer

## Screenshots / Videos
![ezgif com-video-to-gif (18)](https://user-images.githubusercontent.com/6104164/68802227-d300ed80-065d-11ea-934a-ad55351a285b.gif)

## Steps to Test
- Load Landing page
- Scroll all the way down to the bottom
- Change around the size of the browser window
