### PR TITLE
Limit incidents page table to 10 pages.

### DIFF
--- a/client/components/incidents-table/incidents-table.component.html
+++ b/client/components/incidents-table/incidents-table.component.html
@@ -20,6 +20,7 @@
       on-pagination-change="vm.handlePaginationChange({ pagination })"
       position="bottom"
       show-sort="false"
+      max-pages="10"
     ></table-controls>
   </div>
 
@@ -33,6 +34,7 @@
       on-sort-change="vm.handleSortChange({ sort })"
       is-loading="vm.isLoading"
       position="top"
+      max-pages="10"
     ></table-controls>
 
     <!-- Incidents table -->
@@ -71,6 +73,7 @@
       on-sort-change="vm.handleSortChange({ sort })"
       is-loading="vm.isLoading"
       position="bottom"
+      max-pages="10"
     ></table-controls>
   </div>
 </div>

--- a/client/components/table-controls/table-controls.component.js
+++ b/client/components/table-controls/table-controls.component.js
@@ -12,6 +12,7 @@ export class TableControlsController {
   position;
   showSort;
   columnDefs = [];
+  maxPages;
 
   $onInit() {
     this.sort = this.sort || {
@@ -41,7 +42,12 @@ export class TableControlsController {
   }
 
   get totalPages() {
-    return Math.ceil(this.pagination.totalItems / this.pagination.pageSize);
+    let totalPages = Math.ceil(this.pagination.totalItems / this.pagination.pageSize);
+    if(this.maxPages != null) {
+      totalPages = Math.min(this.maxPages, totalPages);
+    }
+
+    return totalPages;
   }
 
   get pageNumbers() {
@@ -129,6 +135,7 @@ export default angular.module('tableControls', [])
       isLoading: '<?',
       position: '@?',
       showSort: '<?',
+      maxPages: '<?',
     },
   })
   .name;


### PR DESCRIPTION
## Overview
Only show up to 10 pages of incidents in the Incidents page table. This is to fix a rendering speed issue for departments with hundreds or thousands of pages of incidents. Elasticsearch also limits paging to 10,000 results, which makes a large number of pages impossible anyways.

## GitHub Issues
- #422 

## Changes
- Added `max-pages` attribute to `table-controls` component.
- Set Incidents page `table-controls` elements' `max-pages` to 10.

## Screenshots / Videos
<img width="1177" alt="Screen Shot 2019-12-16 at 8 21 28 PM" src="https://user-images.githubusercontent.com/3220897/70964713-b4698a00-2041-11ea-9c03-d63d357beb84.png">

## Steps to Test
- Login with a department that has hundreds of thousands of incidents.
- Navigate to Incidents page.
- Page should load quickly and pages should be limited to 10.
