### PR TITLE
First Arriving incident analysis api endpoint.

### DIFF
--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -64,7 +64,7 @@
                 <hr>
               </div>
               <h6 class="heavyheader"> {{ vm.type }} <span ng-if="vm.subtype"> - {{ vm.subtype }} </span> </h6>
-              <p>{{ vm.textSummaries.incidentSummary }}</p>
+              <p>{{ vm.textSummaries.incident_summary }}</p>
             </div>
           </div>
         </div>
@@ -171,7 +171,7 @@
             <div class="location-summary">
               <dl>
                 <dt>Overview</dt>
-                <dd>{{ vm.textSummaries.locationSummary }}</dd>
+                <dd>{{ vm.textSummaries.location_summary }}</dd>
               </dl>
               <dl>
                 <dt>Address</dt>
@@ -342,7 +342,7 @@
           </div>
           <div class="card-body">
             <div class="response-overview-summary">
-              {{ vm.textSummaries.responseSummary }}
+              {{ vm.textSummaries.response_summary }}
             </div>
             <div class="response-overview-stats">
               <div class="response-overview-stat">

--- a/client/components/weather/current-weather.component.html
+++ b/client/components/weather/current-weather.component.html
@@ -1,6 +1,6 @@
 <div class="weather-cube">
   <skycon icon="vm.weather.icon" size="110"></skycon>
-  <h3> {{ vm.textSummaries.situationalAwarenessSummary }}</h3>
+  <h3> {{ vm.textSummaries.situational_awareness_summary }}</h3>
 </div>
 
 <div class="weather-summary">

--- a/server/api/incident/incident.helpers.js
+++ b/server/api/incident/incident.helpers.js
@@ -11,7 +11,7 @@ export function generateTextualSummaries(incident) {
 
   const summaries = {};
   _.forOwn(templates, (t, key) => {
-    summaries[key] = templates[key](i);
+    summaries[_.snakeCase(key)] = templates[key](i);
   });
 
   return summaries;

--- a/server/api/third-party/first-arriving/first-arriving.controller.js
+++ b/server/api/third-party/first-arriving/first-arriving.controller.js
@@ -1,0 +1,64 @@
+import bodybuilder from 'bodybuilder';
+
+import connection from '../../../elasticsearch/connection';
+import { generateAnalysis, generateTextualSummaries } from '../../incident/incident.helpers';
+
+export async function getIncidentAnalysis(req, res) {
+  const bodyBuilder = bodybuilder()
+    .from(0)
+    .size(20)
+    .filter('term', 'description.active', false)
+    .filter('term', 'description.suppressed', false)
+    .sort('description.event_closed', 'desc');
+
+  const esIncidents = await connection.getClient().search({
+    index: req.fireDepartment.es_indices['fire-incident'],
+    body: bodyBuilder.build(),
+  });
+
+  const incidents = esIncidents.hits.hits.map(esIncident => {
+    const source = esIncident._source;
+    const textSummaries = generateTextualSummaries(source);
+    return {
+      description: {
+        event_closed: source.description.event_closed,
+      },
+      address: {
+        latitude: source.address.latitude,
+        longitude: source.address.longitude,
+        address_line1: source.address.address_line1,
+        battalion: source.address.battalion,
+      },
+      text_summaries: {
+        incident_summary: textSummaries.incident_summary,
+        response_summary: textSummaries.response_summary,
+      },
+      durations: {
+        alarm_answer: source.durations.alarm_answer,
+        arrival_from_event_opened: source.durations.arrival_from_event_opened,
+        total_event: source.durations.total_event,
+      },
+      apparatus: source.apparatus.map(apparatus => {
+        return {
+          unit_id: apparatus.unit_id,
+          unit_status: {
+            dispatched: apparatus.unit_status.dispatched,
+          },
+          durations: {
+            travel: {
+              seconds: apparatus.extended_data.travel_duration,
+            },
+            turnout: {
+              seconds: apparatus.extended_data.turnout_duration,
+            },
+          },
+        };
+      }),
+      analysis: generateAnalysis(source),
+    };
+  });
+
+  res.json({
+    incidents,
+  });
+}

--- a/server/api/third-party/first-arriving/index.js
+++ b/server/api/third-party/first-arriving/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+import { Router } from 'express';
+
+import * as controller from './first-arriving.controller';
+import * as auth from '../../../auth/auth.service';
+
+const router = new Router();
+
+router.get(
+  '/incident-analysis',
+  auth.isApiAuthenticated,
+  auth.hasRole('user'),
+  auth.hasFireDepartment,
+  controller.getIncidentAnalysis,
+);
+
+module.exports = router;

--- a/server/api/third-party/index.js
+++ b/server/api/third-party/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+import { Router } from 'express';
+
+const router = new Router();
+
+router.use('/first-arriving', require('./first-arriving'));
+
+module.exports = router;

--- a/server/routes.js
+++ b/server/routes.js
@@ -38,6 +38,7 @@ export default function(app) {
   app.use('/api/workspaces', require('./api/workspace'));
   app.use('/api/fixture-template', require('./api/fixture-template'));
   app.use('/api/admin', require('./api/admin'));
+  app.use('/api/third-party', require('./api/third-party'));
 
   // Kibana
   app.use('/workspaces', require('./kibana/workspace'));


### PR DESCRIPTION
## Overview
Data for the First Arriving Incident Analysis view can now be accessed via the `/api/third-party/first-arriving/incident-analysis` endpoint.

## GitHub Issues
- #425 

## Changes
- Added `/third-party` route for grouping endpoints by organization for external projects.
- Added `/first-arriving` route for First Arriving endpoints.
- Added `/incident-analysis` endpoint for getting data for Incident Analysis view.
- Updated `generateTextualSummaries()` to use snake case keys instead of camel case, and updated UI to use the new key names.

## Steps to Test
- Make a request to `/api/third-party/first-arriving/incident-analysis` passing in a `fireDepartmentId` query param.
- You should receive back the latest 20 incidents for that department with the data required for the Incident Analysis view.
