### PR TITLE
Force sync database schema on seed dev.

### DIFF
--- a/server/config/seedDev.js
+++ b/server/config/seedDev.js
@@ -38,8 +38,8 @@ export default function seedDev() {
 
   Log.info('Seeding development data...');
 
-  return Extension
-    .sync()
+  return sqldb.sequelize.sync({ force: true })
+    .then(() => Extension.sync())
     .then(() => Workspace.sync())
     .then(() => Workspace.destroy({ where: {} }))
     .then(() => AppInstallation.sync())


### PR DESCRIPTION
## Overview
This is just a minor workflow improvement. Anytime I've wanted to switch to a branch with a schema change I've been having to edit `app.js` and set the database sync to forced, then run the app, then revert `app.js`. This just lets you run the `seed:dev` gulp task to sync your schema.