### PR TITLE
First Arriving API

### DIFF
--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -64,7 +64,7 @@
                 <hr>
               </div>
               <h6 class="heavyheader"> {{ vm.type }} <span ng-if="vm.subtype"> - {{ vm.subtype }} </span> </h6>
-              <p>{{ vm.textSummaries.incidentSummary }}</p>
+              <p>{{ vm.textSummaries.incident_summary }}</p>
             </div>
           </div>
         </div>
@@ -171,7 +171,7 @@
             <div class="location-summary">
               <dl>
                 <dt>Overview</dt>
-                <dd>{{ vm.textSummaries.locationSummary }}</dd>
+                <dd>{{ vm.textSummaries.location_summary }}</dd>
               </dl>
               <dl>
                 <dt>Address</dt>
@@ -342,7 +342,7 @@
           </div>
           <div class="card-body">
             <div class="response-overview-summary">
-              {{ vm.textSummaries.responseSummary }}
+              {{ vm.textSummaries.response_summary }}
             </div>
             <div class="response-overview-stats">
               <div class="response-overview-stat">

--- a/client/components/weather/current-weather.component.html
+++ b/client/components/weather/current-weather.component.html
@@ -1,6 +1,6 @@
 <div class="weather-cube">
   <skycon icon="vm.weather.icon" size="110"></skycon>
-  <h3> {{ vm.textSummaries.situationalAwarenessSummary }}</h3>
+  <h3> {{ vm.textSummaries.situational_awareness_summary }}</h3>
 </div>
 
 <div class="weather-summary">

--- a/server/api/incident/incident.helpers.js
+++ b/server/api/incident/incident.helpers.js
@@ -11,7 +11,7 @@ export function generateTextualSummaries(incident) {
 
   const summaries = {};
   _.forOwn(templates, (t, key) => {
-    summaries[key] = templates[key](i);
+    summaries[_.snakeCase(key)] = templates[key](i);
   });
 
   return summaries;

--- a/server/api/third-party/first-arriving/first-arriving.controller.js
+++ b/server/api/third-party/first-arriving/first-arriving.controller.js
@@ -1,0 +1,64 @@
+import bodybuilder from 'bodybuilder';
+
+import connection from '../../../elasticsearch/connection';
+import { generateAnalysis, generateTextualSummaries } from '../../incident/incident.helpers';
+
+export async function getIncidentAnalysis(req, res) {
+  const bodyBuilder = bodybuilder()
+    .from(0)
+    .size(20)
+    .filter('term', 'description.active', false)
+    .filter('term', 'description.suppressed', false)
+    .sort('description.event_closed', 'desc');
+
+  const esIncidents = await connection.getClient().search({
+    index: req.fireDepartment.es_indices['fire-incident'],
+    body: bodyBuilder.build(),
+  });
+
+  const incidents = esIncidents.hits.hits.map(esIncident => {
+    const source = esIncident._source;
+    const textSummaries = generateTextualSummaries(source);
+    return {
+      description: {
+        event_closed: source.description.event_closed,
+      },
+      address: {
+        latitude: source.address.latitude,
+        longitude: source.address.longitude,
+        address_line1: source.address.address_line1,
+        battalion: source.address.battalion,
+      },
+      text_summaries: {
+        incident_summary: textSummaries.incident_summary,
+        response_summary: textSummaries.response_summary,
+      },
+      durations: {
+        alarm_answer: source.durations.alarm_answer,
+        arrival_from_event_opened: source.durations.arrival_from_event_opened,
+        total_event: source.durations.total_event,
+      },
+      apparatus: source.apparatus.map(apparatus => {
+        return {
+          unit_id: apparatus.unit_id,
+          unit_status: {
+            dispatched: apparatus.unit_status.dispatched,
+          },
+          durations: {
+            travel: {
+              seconds: apparatus.extended_data.travel_duration,
+            },
+            turnout: {
+              seconds: apparatus.extended_data.turnout_duration,
+            },
+          },
+        };
+      }),
+      analysis: generateAnalysis(source),
+    };
+  });
+
+  res.json({
+    incidents,
+  });
+}

--- a/server/api/third-party/first-arriving/first-arriving.controller.js
+++ b/server/api/third-party/first-arriving/first-arriving.controller.js
@@ -67,7 +67,7 @@ export async function getIncidentAnalysis(req, res) {
 }
 
 export async function getUnitUtilization(req, res) {
-  const interval = req.query.interval;
+  const interval = (req.query.interval || '').toLowerCase();
 
   const intervalsAllowed = ['shift', 'day', 'week', 'month', 'quarter', 'year'];
   if(!intervalsAllowed.includes(interval)) {
@@ -191,7 +191,7 @@ export async function getUnitUtilization(req, res) {
 }
 
 export async function getTurnoutLeaderboard(req, res) {
-  const interval = req.query.interval;
+  const interval = (req.query.interval || '').toLowerCase();
 
   const intervalsAllowed = ['shift', 'day', 'week', 'month', 'quarter', 'year', 'all'];
   if(!intervalsAllowed.includes(interval)) {

--- a/server/api/third-party/first-arriving/first-arriving.controller.js
+++ b/server/api/third-party/first-arriving/first-arriving.controller.js
@@ -1,7 +1,10 @@
+import _ from 'lodash';
 import bodybuilder from 'bodybuilder';
+import moment from 'moment';
 
 import connection from '../../../elasticsearch/connection';
 import { generateAnalysis, generateTextualSummaries } from '../../incident/incident.helpers';
+import { getUnitBusynessLabel, getUnitBusynessQuintiles } from '../../../util/statistics';
 
 export async function getIncidentAnalysis(req, res) {
   const bodyBuilder = bodybuilder()
@@ -61,4 +64,119 @@ export async function getIncidentAnalysis(req, res) {
   res.json({
     incidents,
   });
+}
+
+export async function getUnitUtilization(req, res) {
+  //
+  // Request data from Elasticsearch.
+  //
+
+  const bodyBuilder = bodybuilder()
+    .size(0)
+    .filter('term', 'description.suppressed', false)
+    .filter('term', 'description.active', false)
+    .filter('range', 'description.event_opened', {
+      time_zone: req.fireDepartment.timezone,
+      gte: moment().subtract(1, 'days').startOf('day').format(),
+      lt: moment().startOf('day').format(),
+    });
+
+  // Unit incident total count / average turnout duration / unit hour utilization.
+  bodyBuilder
+    .agg('nested', { path: 'apparatus' }, 'incidents_by_apparatus', a => a
+      .agg('terms', 'apparatus.unit_id', { size: 1000 }, 'unit_id', b => b
+        .agg('avg', 'apparatus.extended_data.turnout_duration', 'avg_turnout_duration')
+        .agg('sum', 'apparatus.extended_data.event_duration', 'sum_event_duration')
+      )
+    );
+
+  // Unit incident count by category.
+  bodyBuilder
+    .agg('terms', 'description.category', 'incidents_by_category', a => a
+      .agg('nested', { path: 'apparatus' }, 'apparatus', b => b
+        .agg('terms', 'apparatus.unit_id', { size: 1000 }, 'unit_id')
+      )
+    );
+
+  // Send request.
+  const esIncidents = await connection.getClient().search({
+    index: req.fireDepartment.es_indices['fire-incident'],
+    body: bodyBuilder.build(),
+  });
+
+  //
+  // Organize received data.
+  //
+
+  const unitLookups = {
+    incidentTotal: {},
+    fireIncidentTotal: {},
+    emsIncidentTotal: {},
+    avgTurnoutDuration: {},
+    hourUtilizationPercent: {},
+    sumEventDuration: {},
+    busyness: {},
+  };
+
+  // Unit incident total count / average turnout duration / unit hour utilization.
+  for(const bucket of _.get(esIncidents, 'aggregations.incidents_by_apparatus.unit_id.buckets', [])) {
+    const unitId = bucket.key;
+    const incidentTotal = bucket.doc_count;
+    unitLookups.incidentTotal[unitId] = incidentTotal;
+    unitLookups.avgTurnoutDuration[unitId] = bucket.avg_turnout_duration.value;
+    unitLookups.hourUtilizationPercent[unitId] = (bucket.sum_event_duration.value / 60 / 60 / 24) * 100;
+    unitLookups.sumEventDuration[unitId] = bucket.sum_event_duration.value;
+  }
+
+  // Unit incident count by category.
+  for(const bucket of _.get(esIncidents, 'aggregations.incidents_by_category.buckets', [])) {
+    const category = bucket.key.toLowerCase();
+
+    for(const unitBucket of _.get(bucket, 'apparatus.unit_id.buckets', [])) {
+      const unitId = unitBucket.key;
+      const incidentTotal = unitBucket.doc_count;
+      if(category === 'fire') {
+        unitLookups.fireIncidentTotal[unitId] = incidentTotal;
+      } else if(category === 'ems') {
+        unitLookups.emsIncidentTotal[unitId] = incidentTotal;
+      }
+    }
+  }
+
+  // Calculate unit busyness.
+  const unitSumEventDurationList = Object.keys(unitLookups.sumEventDuration)
+    .map(unitId => unitLookups.sumEventDuration[unitId]);
+  const quintiles = getUnitBusynessQuintiles(unitSumEventDurationList);
+
+  for(const unitId of Object.keys(unitLookups.sumEventDuration)) {
+    const sumEventDuration = unitLookups.sumEventDuration[unitId];
+    unitLookups.busyness[unitId] = getUnitBusynessLabel(sumEventDuration, quintiles);
+  }
+
+  //
+  // Build and send response.
+  //
+
+  const apparatus = [];
+  for(const unitId of Object.keys(unitLookups.incidentTotal)) {
+    apparatus.push({
+      unit_id: unitId,
+      metrics: {
+        unit_hour_utilization: {
+          percent: unitLookups.hourUtilizationPercent[unitId] || 0,
+        },
+        avg_turnout_duration: {
+          seconds: unitLookups.avgTurnoutDuration[unitId] || 0,
+        },
+        busyness: unitLookups.busyness[unitId] || 'n/a',
+        responses: {
+          total: unitLookups.incidentTotal[unitId] || 0,
+          fire: unitLookups.fireIncidentTotal[unitId] || 0,
+          ems: unitLookups.emsIncidentTotal[unitId] || 0,
+        },
+      },
+    });
+  }
+
+  res.json({ apparatus });
 }

--- a/server/api/third-party/first-arriving/first-arriving.controller.js
+++ b/server/api/third-party/first-arriving/first-arriving.controller.js
@@ -1,10 +1,12 @@
 import _ from 'lodash';
 import bodybuilder from 'bodybuilder';
 import moment from 'moment';
+import { FirecaresLookup } from '@statengine/shiftly';
 
 import connection from '../../../elasticsearch/connection';
 import { generateAnalysis, generateTextualSummaries } from '../../incident/incident.helpers';
 import { getUnitBusynessLabel, getUnitBusynessQuintiles } from '../../../util/statistics';
+import { BadRequestError } from '../../../util/error';
 
 export async function getIncidentAnalysis(req, res) {
   const bodyBuilder = bodybuilder()
@@ -49,10 +51,10 @@ export async function getIncidentAnalysis(req, res) {
           },
           durations: {
             travel: {
-              seconds: apparatus.extended_data.travel_duration,
+              seconds: parseFloat(apparatus.extended_data.travel_duration),
             },
             turnout: {
-              seconds: apparatus.extended_data.turnout_duration,
+              seconds: parseFloat(apparatus.extended_data.turnout_duration),
             },
           },
         };
@@ -61,12 +63,20 @@ export async function getIncidentAnalysis(req, res) {
     };
   });
 
-  res.json({
-    incidents,
-  });
+  res.json({ incidents });
 }
 
 export async function getUnitUtilization(req, res) {
+  const interval = req.query.interval;
+
+  const intervalsAllowed = ['shift', 'day', 'week', 'month', 'quarter', 'year'];
+  if(!intervalsAllowed.includes(interval)) {
+    throw new BadRequestError(`Parameter "interval" must be one of the following: ${intervalsAllowed.join(' | ')}`)
+  }
+
+  const timeRange = getTimeRange(req.fireDepartment, interval);
+  const timeRangeHours = moment(timeRange.end).diff(timeRange.start, 'hours');
+
   //
   // Request data from Elasticsearch.
   //
@@ -76,9 +86,8 @@ export async function getUnitUtilization(req, res) {
     .filter('term', 'description.suppressed', false)
     .filter('term', 'description.active', false)
     .filter('range', 'description.event_opened', {
-      time_zone: req.fireDepartment.timezone,
-      gte: moment().subtract(1, 'days').startOf('day').format(),
-      lt: moment().startOf('day').format(),
+      gte: timeRange.start,
+      lt: timeRange.end,
     });
 
   // Unit incident total count / average turnout duration / unit hour utilization.
@@ -124,7 +133,7 @@ export async function getUnitUtilization(req, res) {
     const incidentTotal = bucket.doc_count;
     unitLookups.incidentTotal[unitId] = incidentTotal;
     unitLookups.avgTurnoutDuration[unitId] = bucket.avg_turnout_duration.value;
-    unitLookups.hourUtilizationPercent[unitId] = (bucket.sum_event_duration.value / 60 / 60 / 24) * 100;
+    unitLookups.hourUtilizationPercent[unitId] = (bucket.sum_event_duration.value / 60 / 60 / timeRangeHours) * 100;
     unitLookups.sumEventDuration[unitId] = bucket.sum_event_duration.value;
   }
 
@@ -163,20 +172,126 @@ export async function getUnitUtilization(req, res) {
       unit_id: unitId,
       metrics: {
         unit_hour_utilization: {
-          percent: unitLookups.hourUtilizationPercent[unitId] || 0,
+          percent: parseFloat(unitLookups.hourUtilizationPercent[unitId]),
         },
         avg_turnout_duration: {
-          seconds: unitLookups.avgTurnoutDuration[unitId] || 0,
+          seconds: parseFloat(unitLookups.avgTurnoutDuration[unitId]),
         },
         busyness: unitLookups.busyness[unitId] || 'n/a',
         responses: {
-          total: unitLookups.incidentTotal[unitId] || 0,
-          fire: unitLookups.fireIncidentTotal[unitId] || 0,
-          ems: unitLookups.emsIncidentTotal[unitId] || 0,
+          total: parseInt(unitLookups.incidentTotal[unitId]),
+          fire: parseInt(unitLookups.fireIncidentTotal[unitId]),
+          ems: parseInt(unitLookups.emsIncidentTotal[unitId]),
         },
       },
     });
   }
 
   res.json({ apparatus });
+}
+
+export async function getTurnoutLeaderboard(req, res) {
+  const interval = req.query.interval;
+
+  const intervalsAllowed = ['shift', 'day', 'week', 'month', 'quarter', 'year', 'all'];
+  if(!intervalsAllowed.includes(interval)) {
+    throw new BadRequestError(`Parameter "interval" must be one of the following: ${intervalsAllowed.join(' | ')}`)
+  }
+
+  const timeRange = getTimeRange(req.fireDepartment, interval);
+
+  //
+  // Request data from Elasticsearch.
+  //
+
+  const bodyBuilder = bodybuilder()
+    .size(0)
+    .filter('term', 'description.suppressed', false)
+    .filter('term', 'description.active', false)
+    .filter('range', 'description.event_opened', {
+      gte: timeRange.start,
+      lt: timeRange.end,
+    });
+
+  // Unit incident total count / average turnout duration / unit hour utilization.
+  bodyBuilder
+    .agg('nested', { path: 'apparatus' }, 'incidents_by_apparatus', a => a
+      .agg('terms', 'apparatus.unit_id', { size: 1000 }, 'unit_id', b => b
+        .agg('avg', 'apparatus.extended_data.turnout_duration', 'avg_turnout_duration')
+        .agg('percentiles', 'apparatus.extended_data.turnout_duration', 'percentiles_turnout_duration', { percents: [90] })
+      )
+    );
+
+  // Send request.
+  const esIncidents = await connection.getClient().search({
+    index: req.fireDepartment.es_indices['fire-incident'],
+    body: bodyBuilder.build(),
+  });
+
+  //
+  // Organize received data.
+  //
+
+  const apparatus = [];
+
+  for(const bucket of _.get(esIncidents, 'aggregations.incidents_by_apparatus.unit_id.buckets', [])) {
+    apparatus.push({
+      unit_id: bucket.key,
+      metrics: {
+        avg_turnout_duration: {
+          seconds: parseFloat(bucket.avg_turnout_duration.value),
+        },
+        '90th_percentile_turnout_duration': {
+          seconds: parseFloat(bucket.percentiles_turnout_duration.values['90.0']),
+        },
+      },
+    });
+  }
+
+  // Sort with -Infinity/Infinity/NaN at the end.
+  apparatus.sort((a, b) => {
+    const aSeconds = a.metrics.avg_turnout_duration.seconds;
+    const bSeconds = b.metrics.avg_turnout_duration.seconds;
+    if(!isFinite(aSeconds) && !isFinite(bSeconds)) {
+      return 0;
+    } else if(!isFinite(aSeconds)) {
+      return 1;
+    } else if(!isFinite(bSeconds)) {
+      return -1;
+    } else {
+      return aSeconds - bSeconds;
+    }
+  });
+
+  res.json({ apparatus });
+}
+
+//
+// Helpers
+//
+
+function getTimeRange(fireDepartment, interval) {
+  const now = moment().tz(fireDepartment.timezone);
+
+  if(interval === 'shift') {
+    const ShiftConfiguration = FirecaresLookup[fireDepartment.firecares_id];
+    const shiftly = new ShiftConfiguration();
+    const shiftTimeframe = shiftly.shiftTimeFrame(moment(now).subtract(1, 'day').format());
+    return {
+      start: shiftTimeframe.start,
+      end: shiftTimeframe.end,
+    };
+  } else if(['day', 'week', 'month', 'quarter', 'year'].includes(interval)) {
+    return {
+      start: moment(now).subtract(1, `${interval}s`).startOf(interval).format(),
+      end: moment(now).startOf(interval).format(),
+    };
+  } else if(interval === 'all') {
+    return {
+      start: moment(0).tz(fireDepartment.timezone),
+      end: moment(now),
+    };
+  } else {
+    throw new Error(`Interval "${interval}" is not supported.`);
+  }
 }

--- a/server/api/third-party/first-arriving/first-arriving.controller.js
+++ b/server/api/third-party/first-arriving/first-arriving.controller.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import bodybuilder from 'bodybuilder';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { FirecaresLookup } from '@statengine/shiftly';
 
 import connection from '../../../elasticsearch/connection';

--- a/server/api/third-party/first-arriving/index.js
+++ b/server/api/third-party/first-arriving/index.js
@@ -15,4 +15,12 @@ router.get(
   controller.getIncidentAnalysis,
 );
 
+router.get(
+  '/unit-utilization',
+  auth.isApiAuthenticated,
+  auth.hasRole('user'),
+  auth.hasFireDepartment,
+  controller.getUnitUtilization,
+);
+
 module.exports = router;

--- a/server/api/third-party/first-arriving/index.js
+++ b/server/api/third-party/first-arriving/index.js
@@ -23,4 +23,12 @@ router.get(
   controller.getUnitUtilization,
 );
 
+router.get(
+  '/turnout-leaderboard',
+  auth.isApiAuthenticated,
+  auth.hasRole('user'),
+  auth.hasFireDepartment,
+  controller.getTurnoutLeaderboard,
+);
+
 module.exports = router;

--- a/server/api/third-party/first-arriving/index.js
+++ b/server/api/third-party/first-arriving/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+import { Router } from 'express';
+
+import * as controller from './first-arriving.controller';
+import * as auth from '../../../auth/auth.service';
+
+const router = new Router();
+
+router.get(
+  '/incident-analysis',
+  auth.isApiAuthenticated,
+  auth.hasRole('user'),
+  auth.hasFireDepartment,
+  controller.getIncidentAnalysis,
+);
+
+module.exports = router;

--- a/server/api/third-party/index.js
+++ b/server/api/third-party/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+import { Router } from 'express';
+
+const router = new Router();
+
+router.use('/first-arriving', require('./first-arriving'));
+
+module.exports = router;

--- a/server/routes.js
+++ b/server/routes.js
@@ -38,6 +38,7 @@ export default function(app) {
   app.use('/api/workspaces', require('./api/workspace'));
   app.use('/api/fixture-template', require('./api/fixture-template'));
   app.use('/api/admin', require('./api/admin'));
+  app.use('/api/third-party', require('./api/third-party'));
 
   // Kibana
   app.use('/workspaces', require('./kibana/workspace'));

--- a/server/util/statistics.js
+++ b/server/util/statistics.js
@@ -1,0 +1,22 @@
+import percentile from 'percentile';
+
+export function getUnitBusynessLabel(unitSumEventDuration, quintiles) {
+  if(unitSumEventDuration < quintiles['20']) {
+    return 'slow';
+  } else if(unitSumEventDuration > quintiles['80']) {
+    return 'busy';
+  } else {
+    return 'typical';
+  }
+}
+
+export function getUnitBusynessQuintiles(unitSumEventDurationList) {
+  return {
+    '0': percentile(0, unitSumEventDurationList),
+    '20': percentile(20, unitSumEventDurationList),
+    '40': percentile(40, unitSumEventDurationList),
+    '60': percentile(60, unitSumEventDurationList),
+    '80': percentile(80, unitSumEventDurationList),
+    '100': percentile(100, unitSumEventDurationList),
+  };
+}


### PR DESCRIPTION
## Overview
First Arriving API endpoints can now be accessed at `/api/third-party/first-arriving`. Here are each of the views and their endpoints:

**Incident Analysis**
`/api/third-party/first-arriving/incident-analysis`

**Unit Utilization**
`/api/third-party/first-arriving/unit-utilization`

**Turnout Leaderboard**
`/api/third-party/first-arriving/turnout-leaderboard`

## GitHub Issues
- #425 

## Changes
- Added `/api/third-party` route for grouping endpoints by organization for external projects.
- Added `/api/third-party/first-arriving` route for First Arriving endpoints.
- Added endpoints for each First Arriving view.
- Updated `generateTextualSummaries()` to use snake case keys instead of camel case, and updated UI to use the new key names.
- Added `statistics.js` file on server with unit quintile and busyness calculations. The intention is for those functions to eventually be used instead of calculating the same thing client-side for the Units page, but I thought it should wait for a separate PR.

## Steps to Test

**Incident Analysis**
- Make a GET request to `/api/third-party/first-arriving/incident-analysis?fireDepartmentId={x}`.
- You should receive back the latest 20 incidents for that department with the data required for the Incident Analysis view.

**Unit Utilization**
- Make a GET request to `/api/third-party/first-arriving/unit-utilization?fireDepartmentId={x}&interval={x}`. Supported interval values are `shift`, `day`, `week`, `month`, and `year`.
- You should receive data back that matches your requested interval. You can compare this against the data in the app to verify accuracy.

**Turnout Leaderboard**
- Make a GET request to `/api/third-party/first-arriving/turnout-leaderboard?fireDepartmentId={x}&interval={x}`. Supported interval values are `shift`, `day`, `week`, `month`, `year`, and `all`.
- You should receive data back that matches your requested interval. Returned units are sorted by `avg_turnout_duration.seconds`. Any units with missing or erroneous data (infinity/nan/etc) will automatically be sorted to the end of the list with their values set to `null`.

***Unit Utilization** and **Turnout Leaderboard** results are based off of the current date, so in order to get results using older test data, you may need to change line 274 in `first-arriving.controller.js` to `const now = moment('{YOUR_DATE_HERE}').tz(fireDepartment.timezone)` with whatever date best suits your test data.
