### PR TITLE
Sort Units Alphabetically

### DIFF
--- a/client/components/reporting-unit-list/reporting-unit-list.component.js
+++ b/client/components/reporting-unit-list/reporting-unit-list.component.js
@@ -8,6 +8,7 @@ export class ReportingUnitListComponent {
   units;
   onSelect;
   selectedUnitId;
+  sort = 'id';
 
   select(unit) {
     this.onSelect({ selected: unit });

--- a/client/components/reporting-unit-list/reporting-unit-list.html
+++ b/client/components/reporting-unit-list/reporting-unit-list.html
@@ -2,8 +2,23 @@
   <div class="br-mailbox-list-header">
     <input id="searchbox" type="text" class="form-control" placeholder="Search" ng-model="allKeyword" />
   </div><!-- br-mailbox-list-header -->
+  <div class="br-mailbox-list-sort border-bottom">
+    <div class="mb-2 bold">Sort by:</div>
+    <label>
+      <input type="radio" ng-model="vm.sort" ng-value="null">
+        Total Responses
+      <br>
+    </label>
+
+    <label>
+      <input type="radio" ng-model="vm.sort" value="id" checked>
+        Alphabetic
+      <br>
+    </label>
+
+  </div><!-- br-mailbox-list-sort -->
   <div class="br-mailbox-list-body">
-    <div ng-repeat="unit in vm.units | filter: allKeyword">
+    <div ng-repeat="unit in vm.units | filter: allKeyword | orderBy:vm.sort">
       <div class="br-mailbox-list-item border-bottom" ng-class="{'selected': (vm.selectedUnitId === unit.id)}" ng-click="vm.select(unit)">
         <h6 class="tx-14 mb-2 mt-2 tx-gray-800"> {{ unit.id }}</h6>
       </div>

--- a/client/components/reporting-unit-list/reporting-unit-list.scss
+++ b/client/components/reporting-unit-list/reporting-unit-list.scss
@@ -1,4 +1,5 @@
 reporting-unit-list {
+
   .br-mailbox-list {
     position: unset;
     top: unset;
@@ -23,5 +24,12 @@ reporting-unit-list {
         }
       }
     }
+  }
+
+  .br-mailbox-list-sort {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    padding: 10px 20px;
   }
 }


### PR DESCRIPTION
## Overview
Adds radio buttons to sort filtered units alphabetically or by total responses

## GitHub Issues
- #343 

## Changes
- Added UI element to sort via angular filter using a property variable thats set from radio button.

## Screenshots / Videos
<img width="483" alt="Screen Shot 2020-04-05 at 10 49 19 PM" src="https://user-images.githubusercontent.com/2092432/78518950-d1140400-778f-11ea-9600-eceeb462653a.png">

<img width="482" alt="Screen Shot 2020-04-05 at 10 49 32 PM" src="https://user-images.githubusercontent.com/2092432/78518954-d40ef480-778f-11ea-91bb-efbc4d451f24.png">


## Steps to Test
- Open StatEngine
- Login
- Click Units under reports
- Click a sort order
