### PR TITLE
Recap Empty States

### DIFF
--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -386,6 +386,14 @@ table td {
   }
 }
 
+.table-row-empty {
+  padding: 5px;
+  text-align: center;
+  border-bottom: 1px solid $color-geyser;
+  border-right: 1px solid $color-geyser;
+  border-left: 1px solid $color-geyser;
+}
+
 .table {
   @include table(580px);
 }

--- a/client/app/user/user-home/user-home.html
+++ b/client/app/user/user-home/user-home.html
@@ -121,6 +121,7 @@
                           <span class="tx-muted">{{ incident.type }}</span>
                         </p>
                       </li>
+                      <li ng-if="!vm.interestingIncidents.EMS">Looks like you didn't run any EMS calls yesterday.</li>
                     </ul>
                   </div>
                   <div class="col-6">
@@ -133,6 +134,7 @@
                           <span class="tx-muted">{{ incident.type }}</span>
                         </p>
                       </li>
+                      <li ng-if="!vm.interestingIncidents.FIRE">Looks like you didn't run any fire calls yesterday.</li>
                     </ul>
                   </div>
                 </div>
@@ -207,6 +209,9 @@
                       ></bullet-chart>
                     </div>
                   </div>
+                </div>
+                <div class="table-row-empty" ng-if="vm.yesterdayStatSummary.summary.unit.length === 0">
+                  wow, light day - looks like you didn't run any calls yesterday.
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Overview
Add empty states to recap component

## GitHub Issues
- #366 

## Changes
- Empty state HTML

## Screenshots / Videos
<img width="642" alt="Screen Shot 2020-04-13 at 1 43 22 PM" src="https://user-images.githubusercontent.com/2092432/79144578-3322c980-7d8d-11ea-8ced-20f9247ade9a.png">
<img width="644" alt="Screen Shot 2020-04-13 at 1 43 18 PM" src="https://user-images.githubusercontent.com/2092432/79144584-34ec8d00-7d8d-11ea-812d-c955731ea7eb.png">


## Steps to Test
- Login