### PR TITLE
Event Timeline Sort

### DIFF
--- a/client/components/chart/incident-apparatus-timeline.component.js
+++ b/client/components/chart/incident-apparatus-timeline.component.js
@@ -11,6 +11,7 @@ let Timeline;
 export default class IncidentApparatusTimelineComponent {
   initialized = false;
   hammers = [];
+  sort = 'incident_number';
 
   constructor($window) {
     'ngInject';
@@ -56,11 +57,32 @@ export default class IncidentApparatusTimelineComponent {
     this.updateTimeline();
   }
 
+  sortByIncidentNumber(a, b) {
+    return 0;
+  }
+
+  sortByResponseTime(a, b) {
+    const first = a.apparatus_data.extended_data.event_duration;
+    const second = b.apparatus_data.extended_data.event_duration;
+
+    if (first < second) {
+      return 1;
+    } else if (first > second) {
+      return -1;
+    } else {
+      return 0;
+    }
+  }
+
   async updateTimeline() {
     const items = [];
     const groups = [];
+    const sortFn = this.sort === 'incident_number' ? this.sortByIncidentNumber : this.sortByResponseTime;
 
-    let orderedResponses = this.responses.slice(0, 99);
+    let orderedResponses = this.responses
+    .slice(0, 99)
+    .sort(sortFn);
+    
     let order = 1;
     _.forEach(orderedResponses, response => {
       let group = response.description.incident_number;
@@ -74,7 +96,7 @@ export default class IncidentApparatusTimelineComponent {
       const appTimelineData = getApparatusTimeData(u);
       const dispatched = _.get(response, 'apparatus_data.unit_status.dispatched.timestamp');
 
-      if(dispatched) {
+      if  (dispatched) {
         _.forEach(appTimelineData.durations, d => {
           const start = moment(d.start).diff(moment(dispatched));
           // normalize start times

--- a/client/components/chart/incident-apparatus-timeline.html
+++ b/client/components/chart/incident-apparatus-timeline.html
@@ -1,5 +1,17 @@
 <div style="flex: 1; display: flex; flex-direction: column;">
   <div class="text-warning mb-3" style="font-size: 0.75rem">This visualization is limited to the first 100 incidents</div>
+  <div class="mb-2">
+    Sort by: 
+    <label class="ml-2">
+      <input type="radio" ng-model="vm.sort" ng-change="vm.updateTimeline()" value="incident_number">
+        Incident Number
+    </label>
+
+    <label class="ml-2">
+      <input type="radio" ng-model="vm.sort" ng-change="vm.updateTimeline()" value="response_time">
+        Total Response Time
+    </label>
+  </div>
   <div style="flex: 1;" id="apparatus-timeline-container">
     <div style="max-height: 100%;" id="apparatus-timeline"></div>
   </div>


### PR DESCRIPTION
## Overview
Added Ability to sort timeline by response time and incident number

## GitHub Issues
- #295 

## Changes
- UI to sort
- Sort logic

## Screenshots / Videos
<img width="1140" alt="Screen Shot 2020-04-14 at 6 38 58 PM" src="https://user-images.githubusercontent.com/2092432/79281060-0b605e00-7e80-11ea-8bd2-48b0faa4891a.png">
<img width="1169" alt="Screen Shot 2020-04-14 at 6 38 52 PM" src="https://user-images.githubusercontent.com/2092432/79281064-0dc2b800-7e80-11ea-8229-1fdfd8f6ccc2.png">


## Steps to Test
- Login
- Click Units under Reports
- Click a unit that has data
- Click on timeline tab
- Change sort by