### PR TITLE
Added empty state to unit & personnel block on incident analysis page

### DIFF
--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -385,7 +385,13 @@
             <h6 class="card-title">Units & Personnel</h6>
           </div>
           <div class="card-body">
-            <div ng-repeat="apparatus in vm.incidentData.incident.apparatus | orderBy:vm.sortByLength" class="mt-2 personnel-container">
+            <div class="h-100 d-flex flex-center-center" ng-if="vm.incidentData.incident.apparatus.length === 0">
+              <h5 class="no-data d-flex flex-center-center flex-column">
+                <i class="no-data-icon fa fa-bar-chart mb-0"></i><br>
+                No unit data available
+              </h5>
+            </div>
+            <div ng-if="vm.incidentData.incident.apparatus.length > 0" ng-repeat="apparatus in vm.incidentData.incident.apparatus | orderBy:vm.sortByLength" class="mt-2 personnel-container">
               <div class="unit-circle">
                 <i class="fa fa-truck"></i>
               </div>


### PR DESCRIPTION
## Overview
Added empty state to incident analysis page for units & personnel where units array is empty

## GitHub Issues
- #477 

## Changes
- Added view logic

## Screenshots / Videos
<img width="627" alt="Screen Shot 2020-06-04 at 1 12 48 PM" src="https://user-images.githubusercontent.com/2092432/83789721-1dcb6c80-a665-11ea-8a53-17daf40ca941.png">

## Steps to Test
- Find Incident with 0 units
- Should see empty state
