### PR TITLE
Add "Event Opened" column in incidents search

### DIFF
--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -35,6 +35,25 @@ export default class IncidentSearchController {
     this.fireDepartment = currentPrincipal.FireDepartment;
     this.Modal = Modal;
 
+    this.initUiGridColumnDefs();
+
+    this.refreshIncidentsList = _.debounce(this.refreshIncidentsList, 350, {
+      leading: true,
+      trailing: true,
+    });
+
+    this.initRangeFilter();
+
+    angular.element(this.$window).bind('resize', () => {
+      this.initUiGridColumnDefs();
+    });
+  }
+
+  async $onInit() {
+    this.refreshIncidentsList();
+  }
+
+  initUiGridColumnDefs() {
     this.uiGridColumnDefs = [{
       field: 'description.incident_number',
       displayName: 'Incident Number',
@@ -80,16 +99,17 @@ export default class IncidentSearchController {
       cellTooltip: true,
     }];
 
-    this.refreshIncidentsList = _.debounce(this.refreshIncidentsList, 350, {
-      leading: true,
-      trailing: true,
-    });
-
-    this.initRangeFilter()
-  }
-
-  async $onInit() {
-    this.refreshIncidentsList();
+    // Shorten date formats on mid-size screen widths.
+    if (this.$window.innerWidth >= 1200 && this.$window.innerWidth < 1500) {
+      this.uiGridColumnDefs
+        .filter(columnDef => (
+          columnDef.field === 'description.event_opened' ||
+          columnDef.field === 'description.event_closed'
+        ))
+        .forEach(columnDef => {
+          columnDef.cellFilter = 'date:\'MM/dd/yy HH:mm:ss\'';
+        });
+    }
   }
 
   async refreshIncidentsList() {

--- a/client/app/incident/incident-search/incident-search.controller.js
+++ b/client/app/incident/incident-search/incident-search.controller.js
@@ -39,13 +39,21 @@ export default class IncidentSearchController {
       field: 'description.incident_number',
       displayName: 'Incident Number',
       cellTemplate: '<div class="ui-grid-cell-contents"><a href="#" ui-sref="site.incident.analysis({ id: grid.getCellValue(row, col) })">{{ grid.getCellValue(row, col ) }}</a></div>',
+      cellTooltip: true,
     }, {
       field: 'address.address_line1',
-      displayName: 'Address'
+      displayName: 'Address',
+      cellTooltip: true,
+    }, {
+      field: 'description.event_opened',
+      displayName: 'Event Opened',
+      cellFilter: 'date:\'MMM d, y HH:mm:ss\'',
+      cellTooltip: true,
     }, {
       field: 'description.event_closed',
       displayName: 'Event Closed',
-      cellFilter: 'date:"MMM d, y HH:mm:ss"',
+      cellFilter: 'date:\'MMM d, y HH:mm:ss\'',
+      cellTooltip: true,
       defaultSort: {
         direction: 'desc',
         priority: 0,
@@ -54,18 +62,22 @@ export default class IncidentSearchController {
       field: 'durations.total_event.seconds',
       displayName: 'Event Duration',
       cellFilter: 'humanizeDuration',
+      cellTooltip: true,
     }, {
       field: 'description.units_count',
       displayName: '# Units',
       width: 100,
       enableSorting: false,
+      cellTooltip: true,
     }, {
       field: 'description.category',
       displayName: 'Category',
       width: 100,
+      cellTooltip: true,
     }, {
       field: 'description.type',
       displayName: 'Type',
+      cellTooltip: true,
     }];
 
     this.refreshIncidentsList = _.debounce(this.refreshIncidentsList, 350, {
@@ -107,7 +119,7 @@ export default class IncidentSearchController {
     this.isLoading = false;
     this.isLoadingFirst = false;
 
-    // On mobile, automaticallys scroll back to the top on data refresh.
+    // On mobile, automatically scroll back to the top on data refresh.
     if(this.$window.innerWidth <= 1200) {
       const page = angular.element('html')[0];
       page.scrollTop = 0;

--- a/client/components/incidents-table/incidents-table.component.js
+++ b/client/components/incidents-table/incidents-table.component.js
@@ -104,8 +104,16 @@ export class IncidentsTableController {
       },
     };
 
-    this.$scope.$watch('minRowsToShow', () => {
-      this.uiGridOptions.minRowsToShow = this.minRowsToShow;
+    this.$scope.$watch('vm.minRowsToShow', () => {
+      if (this.uiGridOptions) {
+        this.uiGridOptions.minRowsToShow = this.minRowsToShow;
+      }
+    });
+
+    this.$scope.$watch('vm.uiGridColumnDefs', () => {
+      if (this.uiGridOptions) {
+        this.uiGridOptions.columnDefs = this.uiGridColumnDefs;
+      }
     });
 
     // In sort select only show columns with sorting enabled.

--- a/client/components/logo/logo.component.js
+++ b/client/components/logo/logo.component.js
@@ -8,7 +8,6 @@ export class LogoController {
   }
 
   src() {
-    console.dir(this.department.logo_link)
     if(this.department.logo_link) return this.department.logo_link;
   }
 }


### PR DESCRIPTION
## Overview
Pretty straightforward... however, with the addition of this column, the dates started getting truncated on mid-size screen widths. So I used a more condensed date format between 1200px and 1500px screen widths. I also added tooltips for all of the columns, since they'll be truncated more easily now.

## GitHub Issues
- #493 

## Changes
- Updated `incidents-table` component to include "Event Opened" column
- Added tooltips to `incidents-table` columns
- Shortened `incidents-table` dates on mid-size screens

## Screenshots / Videos
<img width="1420" alt="Screen Shot 2020-06-17 at 2 17 57 AM" src="https://user-images.githubusercontent.com/3220897/84879992-d4a1f200-b040-11ea-9660-e2cb65b81107.png">
