### PR TITLE
Auto Populate Units in Move Up Model

### DIFF
--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -49,7 +49,7 @@ $ionicons-font-path: '/assets/fonts/Ionicons/';
 @import "~tippy.js/dist/tippy.css";
 @import "~vis/dist/vis.css";
 @import "~spectrum-colorpicker/spectrum.css";
-
+@import "~flatpickr/dist/flatpickr.css";
 
 // Theme import
 @import "../themes/bracket-plus/scss/bracket";

--- a/client/app/moveup/moveup-home/moveup-home.html
+++ b/client/app/moveup/moveup-home/moveup-home.html
@@ -40,17 +40,27 @@
         </div>
 
         <div class="card-body p-0" ng-hide="vm.inputMinimized">
-          <div class="form-group d-flex mt-2 pl-4 pt-2 flex-column">
+          <div class="form-group mt-2 pl-4 pt-2 flex-column move-up-controls">
+            <div>
+              <div>
+                <label class="mb-0 d-flex align-items-center">
+                  <strong>Covered Time</strong>
+                  <a class="info-icon se-icon-info tippy ml-2" href="" data-tippy-html='#coverageTippy'>&nbsp;</a>
+                </label>
+              </div>
+              <div class="w-50 flex-start-center">
+                <input type="range" min="1" max="7" ng-model="vm.payload.covered_time" class="form-control-range w180 mr-3" />
+                <input type="text" ng-disabled="true" ng-model="vm.payload.covered_time" class="form-control w40 p-2" />
+                <div class="ml-2">Minutes</div>
+              </div>
+            </div>
             <div>
               <label class="mb-0 d-flex align-items-center">
-                <strong>Covered Time</strong>
-                <a class="info-icon se-icon-info tippy ml-2" href="" data-tippy-html='#coverageTippy'>&nbsp;</a>
+                <strong>Auto-populate Units</strong>
+                <a class="info-icon se-icon-info tippy ml-2" href="" data-tippy-html='#autoPopulateTippy'>&nbsp;</a>
               </label>
-            </div>
-            <div class="w-50 flex-start-center">
-              <input type="range" min="1" max="7" ng-model="vm.payload.covered_time" class="form-control-range w180 mr-3" />
-              <input type="text" ng-disabled="true" ng-model="vm.payload.covered_time" class="form-control w40 p-2" />
-              <div class="ml-2">Minutes</div>
+              <input class="pickr" placeholder="Select Time Period" />
+              <button class="btn btn-primary btn-sm ml-2" ng-click="vm.getAvailableUnit()">Auto-populate</button>
             </div>
           </div>
 
@@ -168,5 +178,9 @@
 
   <div id="coverageTippy" style="display: none;">
     Coverage time is the targeted response time the optimiziation will attempt to fulfill.
+  </div>
+
+  <div id="autoPopulateTippy"style="display: none;">
+    Auto Populates checks all units availability for the provided date and attempts to assign the availability. If no date is provided, it will default to now.
   </div>
 </div>

--- a/client/app/moveup/moveup-home/moveup-home.scss
+++ b/client/app/moveup/moveup-home/moveup-home.scss
@@ -82,6 +82,20 @@
     padding: 20px;
   }
 
+  .move-up-controls {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: 1fr;
+    grid-column-gap: 0px;
+    grid-row-gap: 0px;
+  }
+
+  .pickr {
+    border-radius: 2px;
+    border: solid 1px #cbd6df;
+    padding: 5px 10px;
+  }
+
   .optimize-switcher-container {
     display: flex;
     align-items: center;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10394,6 +10394,11 @@
         }
       }
     },
+    "flatpickr": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.3.tgz",
+      "integrity": "sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ=="
+    },
     "flatted": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "express-sequelize-session": "0.4.0",
     "express-session": "^1.11.3",
     "fast-json-patch": "^2.0.6",
+    "flatpickr": "^4.6.3",
     "font-awesome": ">=4.1.0",
     "generate-password": "^1.4.2",
     "grpc": "^1.18.0",

--- a/server/api/fire-department/fire-department.controller.js
+++ b/server/api/fire-department/fire-department.controller.js
@@ -227,13 +227,14 @@ export async function getStations(req, res) {
 
 export async function getJurisdictionalBoundary(req, res) {
   const firecares_id = req.fireDepartment.firecares_id;
-  const { FIRECARES_USERNAME, FIRECARES_API_KEY } = process.env;
-  const url = `https://firecares.org/api/v1/fire-departments/${firecares_id}/?format=json&username=${FIRECARES_USERNAME}&api_key=${FIRECARES_API_KEY}`;
+  const { FIRECARE_USERNAME, FIRECARE_API_KEY } = process.env;
+  const url = `https://firecares.org/api/v1/fire-departments/${firecares_id}/?format=json&username=${FIRECARE_USERNAME}&api_key=${FIRECARE_API_KEY}`;
 
   try  {
     const { data } = await axios.get(url);
     return res.json(data);
   } catch (err) {
+    console.log(err);
     return res.status(500);
   }
 }

--- a/server/api/units/index.js
+++ b/server/api/units/index.js
@@ -17,6 +17,14 @@ router.get(
 );
 
 router.get(
+  '/available',
+  auth.isApiAuthenticated,
+  auth.hasRole('user'),
+  auth.hasFireDepartment,
+  controller.getAvailableUnits,
+);
+
+router.get(
   '/:id/responses',
   auth.isApiAuthenticated,
   auth.hasRole('user'),

--- a/server/api/units/unit.controller.js
+++ b/server/api/units/unit.controller.js
@@ -1,5 +1,6 @@
 import bodybuilder from 'bodybuilder';
 import _ from 'lodash';
+import moment from 'moment-timezone';
 
 import connection from '../../elasticsearch/connection';
 
@@ -7,13 +8,17 @@ function getIncidentIndex(req) {
   return req.user.FireDepartment.get().es_indices['fire-incident'];
 }
 
+function getApparatusIndex(req) {
+  return req.user.FireDepartment.get().es_indices['apparatus-fire-incident'];
+}
+
 export async function getUnits(req, res) {
   const searchBody = bodybuilder()
     .size(0)
     .aggregation('nested', { path: 'apparatus' }, 'apparatus', agg => agg
       .aggregation('terms', 'apparatus.unit_id', { size: 10000 }, unitAggr => unitAggr
-          .aggregation('terms', 'apparatus.station', { size: 10000 })
-          .aggregation('terms', 'apparatus.unit_type', { size: 10000 })
+        .aggregation('terms', 'apparatus.station', { size: 10000 })
+        .aggregation('terms', 'apparatus.unit_type', { size: 10000 })
       )
     )
     .build();
@@ -25,14 +30,14 @@ export async function getUnits(req, res) {
 
   let unitBuckets = _.get(esRes, 'aggregations.apparatus["agg_terms_apparatus.unit_id"].buckets');
 
-  if(unitBuckets) {
+  if (unitBuckets) {
     const response = unitBuckets
       .map(({ key, doc_count, ...rest }) => {
         const typeBucket = rest['agg_terms_apparatus.unit_type'].buckets;
         const stationBucket = rest['agg_terms_apparatus.station'].buckets;
-        
+
         if (typeBucket && typeBucket.length && stationBucket && stationBucket.length) {
-          return { 
+          return {
             id: key,
             incidentCount: doc_count,
             unit_type: typeBucket[0].key,
@@ -48,4 +53,36 @@ export async function getUnits(req, res) {
   }
 
   return res.send([]);
+}
+
+export async function getAvailableUnits(req, res) {
+  let fd = req.user.FireDepartment.get();
+  const now = moment().tz(fd.timezone).format();
+  const date = req.query.datetime || now;
+
+  const searchBody = bodybuilder()
+    .size(0)
+    .rawOption('_source', [
+      'apparatus_data.unit_id',
+      'apparatus_data.unit_status.*'
+    ])
+    .filter('range', 'apparatus_data.dispatched.timestamp', { gte: date })
+    .filter('bool', b => b
+      .orFilter('range', 'apparatus_data.cleared.timestamp', { let: date })
+      .orFilter('range', 'apparatus_data.available.timestamp', { let: date })
+     )
+    .aggregation('terms', 'apparatus_data.unit_id');
+  
+  const esRes = await connection.getClient().search({
+    index: getApparatusIndex(req),
+    body: searchBody
+  });
+
+  try {
+    const units = esRes.hits.hits.map(hit => hit._source.apparatus_data);
+    return res.send(units);
+  } catch (err) {
+    console.error(err);
+    return res.send([]);
+  }
 }


### PR DESCRIPTION
## Overview
Added ability to auto populate the units availability from datetime

## GitHub Issues
- #499 

## Changes
- Added controls to select date and get unit availability for given date
- Added endpoint to fetch availability from ES from given date

## Screenshots / Videos
<img width="1289" alt="Screen Shot 2020-06-19 at 10 21 50 PM" src="https://user-images.githubusercontent.com/2092432/85189540-fcca6480-b27d-11ea-8f95-1771dbf8e931.png">
<img width="1248" alt="Screen Shot 2020-06-19 at 10 21 56 PM" src="https://user-images.githubusercontent.com/2092432/85189541-fd62fb00-b27d-11ea-8959-5ab268cf8d91.png">


## Steps to Test
- Navigate to Move Up Model view
- Selected a date under auto populate
- Click auto populate
- See availability changes
