### PR TITLE
Switch incident count to length of erf_response_values array vs erf_t…

### DIFF
--- a/server/api/effective-response-force/effective-response-force.controller.js
+++ b/server/api/effective-response-force/effective-response-force.controller.js
@@ -122,7 +122,7 @@ export function calculatePercentiles(req, res, next) {
     const erf_travel_values = _.filter(_.map(req.erfStats[i], 'erf_travel'), val => val > 0);
 
     req.summerizedStats[i] = {
-      num_of_incidents: erf_total_response_values.length,
+      num_of_incidents: erf_response_values.length,
       erf_total_response: percentile(90, erf_total_response_values),
       erf_response: percentile(90, erf_response_values),
       erf_travel: percentile(90, erf_travel_values),


### PR DESCRIPTION
…otal_response_values, since erf_total_response_values requires psap_answer_time to be set and erf_response_values does not.

This solution was recommended by Chop in order to fix:  https://app.asana.com/0/1171839564521673/1197036456104612.