### PR TITLE
fix(incidentAnalysis): hide subtype if empty

### DIFF
--- a/client/app/incident/incident-analysis/incident-analysis.controller.js
+++ b/client/app/incident/incident-analysis/incident-analysis.controller.js
@@ -279,4 +279,8 @@ export default class IncidentAnalysisController {
   sortByLength = apparatus => {
     return apparatus.personnel.length;
   }
+
+  isEmpty = (someString) => {
+    return (someString === null || someString === undefined || someString === '');
+  }
 }

--- a/client/app/incident/incident-analysis/incident-analysis.controller.js
+++ b/client/app/incident/incident-analysis/incident-analysis.controller.js
@@ -279,8 +279,4 @@ export default class IncidentAnalysisController {
   sortByLength = apparatus => {
     return apparatus.personnel.length;
   }
-
-  isEmpty = (someString) => {
-    return (someString === null || someString === undefined || someString === '');
-  }
 }

--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -88,9 +88,9 @@
               <span class="incident-summary-row-label">Event Type:</span>
               <span>{{ vm.incident.description.type }}</span>
             </div>
-            <div class="incident-summary-row">
+            <div *ngif="isEmpty(vm.subtype)" class="incident-summary-row">
               <span class="incident-summary-row-label">Event Sub-Type:</span>
-              <span>{{ vm.incident.description.subtype }}</span>
+              <span>{{ vm.subtype }}</span>
             </div>
             <div class="incident-summary-row">
               <span class="incident-summary-row-label">Date:</span>

--- a/client/app/incident/incident-analysis/incident-analysis.html
+++ b/client/app/incident/incident-analysis/incident-analysis.html
@@ -88,9 +88,9 @@
               <span class="incident-summary-row-label">Event Type:</span>
               <span>{{ vm.incident.description.type }}</span>
             </div>
-            <div *ngif="isEmpty(vm.subtype)" class="incident-summary-row">
+            <div ng-if="vm.incident.description.subtype && vm.incident.description.subtype.length > 0" class="incident-summary-row">
               <span class="incident-summary-row-label">Event Sub-Type:</span>
-              <span>{{ vm.subtype }}</span>
+              <span>{{ vm.incident.description.subtype }}</span>
             </div>
             <div class="incident-summary-row">
               <span class="incident-summary-row-label">Date:</span>


### PR DESCRIPTION
## Overview
On Incident report: if the subtype is empty, do not display

## GitHub Issues
- https://app.asana.com/0/1192964035696480/1197938883939891

## Changes
-

## Screenshots / Videos


## Steps to Test
-
