### PR TITLE
Fixed the setFireDepartment function to remove logout and reload state

### DIFF
--- a/client/app/incident/incident-analysis/incident-analysis.controller.js
+++ b/client/app/incident/incident-analysis/incident-analysis.controller.js
@@ -277,6 +277,6 @@ export default class IncidentAnalysisController {
   };
 
   sortByLength = apparatus => {
-    return apparatus.personnel.length;
+    return apparatus && apparatus.personnel && apparatus.personnel.length;
   }
 }

--- a/client/app/user/user-home/user-home.controller.js
+++ b/client/app/user/user-home/user-home.controller.js
@@ -123,8 +123,7 @@ export default class UserHomeController {
       this.principal.fire_department__id = fd._id;
       this.UserService.update({ id: this.principal._id }, this.principal).$promise
         .then(() => {
-          this.PrincipalService.logout();
-          this.$state.go('site.main.main');
+          this.$state.reload();
         })
         .catch(err => {
           console.error('error switching fire departments');


### PR DESCRIPTION
## Overview
Currently when you change department it logs you out inorder to switch departments which is very annoying. I removed the logout logic and reload the state to reflect the new department.

## GitHub Issues
- https://app.asana.com/0/1179442471684209/1199234262709937/f

## Changes
- Changed setFireDepartment function 

## Screenshots / Videos


## Steps to Test
-
