### PR TITLE
Fixes instances of git+ssh urls since there are no ssh keys inside the docker container.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1514,7 +1514,7 @@
       "integrity": "sha1-D9BloZkxUX++zmZZbTJdcrbgYEE="
     },
     "node_modules/angular-skycons": {
-      "resolved": "git+ssh://git@github.com/projectweekend/angular-skycons.git#78d38904b66259cbddf91b5475e424476903ca8d"
+      "resolved": "git+https://github.com/projectweekend/angular-skycons.git#78d38904b66259cbddf91b5475e424476903ca8d"
     },
     "node_modules/angular-spectrum-colorpicker": {
       "version": "1.4.5",
@@ -10281,7 +10281,7 @@
       }
     },
     "node_modules/emitter": {
-      "resolved": "git+ssh://git@github.com/Mango/emitter.git#41ab8a3956269c7ed468bde50203e15b3274152f"
+      "resolved": "git+https://github.com/Mango/emitter.git#41ab8a3956269c7ed468bde50203e15b3274152f"
     },
     "node_modules/emitter-component": {
       "version": "1.1.1",
@@ -35785,7 +35785,7 @@
       "integrity": "sha1-D9BloZkxUX++zmZZbTJdcrbgYEE="
     },
     "angular-skycons": {
-      "version": "git+ssh://git@github.com/projectweekend/angular-skycons.git#78d38904b66259cbddf91b5475e424476903ca8d",
+      "version": "git+http://github.com/projectweekend/angular-skycons.git#78d38904b66259cbddf91b5475e424476903ca8d",
       "from": "angular-skycons@github:projectweekend/angular-skycons"
     },
     "angular-spectrum-colorpicker": {
@@ -43469,7 +43469,7 @@
       }
     },
     "emitter": {
-      "version": "git+ssh://git@github.com/Mango/emitter.git#41ab8a3956269c7ed468bde50203e15b3274152f",
+      "version": "git+https://github.com/Mango/emitter.git#41ab8a3956269c7ed468bde50203e15b3274152f",
       "from": "emitter@git+https://github.com/Mango/emitter.git#0.0.7"
     },
     "emitter-component": {


### PR DESCRIPTION
This bug may resurface, because it appears one or more transitive dependencies use `git+ssh` urls in dependency lists.